### PR TITLE
Make client sync, move to 2018 edition and more

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.3.0"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """
-API bindings for Fortanix SDKMS
+API bindings for Fortanix DSM (a.k.a. Fortanix SDKMS)
 """
 readme = "README.md"
 repository = "https://github.com/fortanix/sdkms-client-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/fortanix/sdkms-client-rust"
 documentation = "https://docs.rs/sdkms"
 homepage = "https://fortanix.com/products/sdkms/"
 categories = ["api-bindings"]
+edition = "2018"
 
 [features]
 default = ["hyper-native-tls"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,11 @@ default = ["hyper-native-tls"]
 
 [dependencies]
 chrono = "0.4"
-serde = "1.0"
-serde_derive = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 hyper-native-tls = { version = "0.3", optional = true }
 hyper = "0.10"
-uuid = { version = "0.7", features = ["serde", "v4"] }
+uuid = { version = "0.8", features = ["serde", "v4"] }
 rustc-serialize = "0.3"
 bitflags = "1.0"
 url = "1.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdkms"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """

--- a/examples/approval_request.rs
+++ b/examples/approval_request.rs
@@ -1,7 +1,3 @@
-extern crate env_logger;
-extern crate rustc_serialize;
-extern crate sdkms;
-
 use rustc_serialize::base64::{ToBase64, STANDARD};
 use sdkms::api_model::*;
 use sdkms::{Error as SdkmsError, SdkmsClient};

--- a/examples/crud.rs
+++ b/examples/crud.rs
@@ -1,8 +1,3 @@
-extern crate chrono;
-extern crate env_logger;
-extern crate rand;
-extern crate sdkms;
-
 use chrono::Local;
 use rand::prelude::*;
 use sdkms::api_model::*;

--- a/examples/encrypt_decrypt.rs
+++ b/examples/encrypt_decrypt.rs
@@ -1,6 +1,3 @@
-extern crate env_logger;
-extern crate sdkms;
-
 use sdkms::api_model::*;
 use sdkms::{Error as SdkmsError, SdkmsClient};
 

--- a/examples/get_user.rs
+++ b/examples/get_user.rs
@@ -1,7 +1,3 @@
-extern crate env_logger;
-extern crate sdkms;
-extern crate uuid;
-
 use sdkms::api_model::*;
 use sdkms::{Error as SdkmsError, SdkmsClient};
 use std::str::FromStr;

--- a/examples/invoke_plugin.rs
+++ b/examples/invoke_plugin.rs
@@ -1,11 +1,5 @@
-extern crate env_logger;
-extern crate sdkms;
-extern crate serde;
-#[macro_use]
-extern crate serde_derive;
-extern crate uuid;
-
 use sdkms::{Error as SdkmsError, SdkmsClient};
+use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use uuid::Uuid;
 

--- a/examples/plugin_approval_request.rs
+++ b/examples/plugin_approval_request.rs
@@ -1,14 +1,7 @@
-extern crate env_logger;
-extern crate rustc_serialize;
-extern crate sdkms;
-#[macro_use]
-extern crate serde_derive;
-extern crate serde_json;
-extern crate uuid;
-
 use rustc_serialize::base64::{ToBase64, STANDARD};
 use sdkms::api_model::*;
 use sdkms::{Error as SdkmsError, SdkmsClient};
+use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use std::{thread, time};
 use uuid::Uuid;

--- a/examples/session.rs
+++ b/examples/session.rs
@@ -1,6 +1,3 @@
-extern crate env_logger;
-extern crate sdkms;
-
 use sdkms::api_model::*;
 use sdkms::{Error as SdkmsError, SdkmsClient};
 

--- a/examples/sign_verify.rs
+++ b/examples/sign_verify.rs
@@ -1,6 +1,3 @@
-extern crate env_logger;
-extern crate sdkms;
-
 use sdkms::api_model::*;
 use sdkms::{Error as SdkmsError, SdkmsClient};
 

--- a/src/api_model.rs
+++ b/src/api_model.rs
@@ -18,7 +18,7 @@ use std::str::FromStr;
 use std::{error, fmt, io};
 use uuid::Uuid;
 
-pub use generated::*;
+pub use crate::generated::*;
 
 /// Arbitrary binary data that is serialized/deserialized to/from base 64 string.
 #[derive(Default, Clone, Debug, Eq, PartialEq, Hash)]
@@ -114,10 +114,12 @@ impl<'de> Deserialize<'de> for Time {
         let s: String = Deserialize::deserialize(deserializer)?;
         Utc.datetime_from_str(&s, ISO_8601_FORMAT)
             .map(|t| Time(t.timestamp() as u64))
-            .map_err(|_| D::Error::invalid_value(
-                serde::de::Unexpected::Str(&s),
-                &"Date/time in ISO 8601 format",
-            ))
+            .map_err(|_| {
+                D::Error::invalid_value(
+                    serde::de::Unexpected::Str(&s),
+                    &"Date/time in ISO 8601 format",
+                )
+            })
     }
 }
 
@@ -149,7 +151,7 @@ pub enum Error {
     EncoderError(serde_json::error::Error),
     IoError(io::Error),
     NetworkError(hyper::Error),
-#[cfg(feature = "hyper-native-tls")]
+    #[cfg(feature = "hyper-native-tls")]
     TlsError(native_tls::Error),
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -7,16 +7,10 @@
 use crate::api_model::*;
 use crate::operations::*;
 
-#[cfg(feature = "hyper-native-tls")]
-use hyper::client::Pool;
 use hyper::header::{Authorization, ContentType};
 use hyper::method::Method;
-#[cfg(feature = "hyper-native-tls")]
-use hyper::net::HttpsConnector;
 use hyper::status::StatusCode;
 use hyper::Client as HyperClient;
-#[cfg(feature = "hyper-native-tls")]
-use hyper_native_tls::NativeTlsClient;
 use rustc_serialize::base64::{ToBase64, STANDARD};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -94,6 +88,10 @@ impl SdkmsClientBuilder {
             None => {
                 #[cfg(feature = "hyper-native-tls")]
                 {
+                    use hyper::client::Pool;
+                    use hyper::net::HttpsConnector;
+                    use hyper_native_tls::NativeTlsClient;
+
                     let ssl = NativeTlsClient::new()?;
                     let connector = HttpsConnector::new(ssl);
                     let client = HyperClient::with_connector(Pool::with_connector(

--- a/src/generated/accounts_generated.rs
+++ b/src/generated/accounts_generated.rs
@@ -5,6 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::*;
+use serde::{Deserialize, Serialize};
 
 /// Type of subscription.
 #[derive(Copy, PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]

--- a/src/generated/approval_requests_generated.rs
+++ b/src/generated/approval_requests_generated.rs
@@ -5,6 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::*;
+use serde::{Deserialize, Serialize};
 
 /// A Principal who can approve or deny an approval request.
 #[derive(Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize, Clone)]

--- a/src/generated/apps_generated.rs
+++ b/src/generated/apps_generated.rs
@@ -5,6 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::*;
+use serde::{Deserialize, Serialize};
 
 /// Operations allowed to be performed by an app.
 pub use self::app_permissions::AppPermissions;

--- a/src/generated/common_generated.rs
+++ b/src/generated/common_generated.rs
@@ -5,6 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::*;
+use serde::{Deserialize, Serialize};
 
 /// Operations allowed to be performed on a given key.
 pub use self::key_operations::KeyOperations;

--- a/src/generated/crypto_generated.rs
+++ b/src/generated/crypto_generated.rs
@@ -5,6 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::*;
+use serde::{Deserialize, Serialize};
 
 /// A cryptographic algorithm.
 #[derive(Debug, Eq, PartialEq, Copy, Hash, Serialize, Deserialize, Clone)]

--- a/src/generated/external_roles_generated.rs
+++ b/src/generated/external_roles_generated.rs
@@ -5,6 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::*;
+use serde::{Deserialize, Serialize};
 
 /// Type of an external role.
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]

--- a/src/generated/groups_generated.rs
+++ b/src/generated/groups_generated.rs
@@ -5,6 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::*;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Group {

--- a/src/generated/keys_generated.rs
+++ b/src/generated/keys_generated.rs
@@ -5,6 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::*;
+use serde::{Deserialize, Serialize};
 
 #[derive(Default, Debug, Serialize, Deserialize, Clone)]
 pub struct SobjectRequest {

--- a/src/generated/mod.rs
+++ b/src/generated/mod.rs
@@ -4,10 +4,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use api_model::*;
-use client::{PendingApproval, Result, SdkmsClient};
+use crate::api_model::*;
+use crate::client::{PendingApproval, Result, SdkmsClient};
+use crate::operations::*;
 use hyper::method::Method;
-use operations::*;
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 use uuid::Uuid;
@@ -97,24 +97,36 @@ impl fmt::Display for ApprovalStatus {
 
 impl Default for AppSort {
     fn default() -> Self {
-        AppSort::ByAppId { order: Order::Ascending, start: None }
+        AppSort::ByAppId {
+            order: Order::Ascending,
+            start: None,
+        }
     }
 }
 
 impl Default for SobjectSort {
     fn default() -> Self {
-        SobjectSort::ByKid { order: Order::Ascending, start: None }
+        SobjectSort::ByKid {
+            order: Order::Ascending,
+            start: None,
+        }
     }
 }
 
 impl Default for PluginSort {
     fn default() -> Self {
-        PluginSort::ByPluginId { order: Order::Ascending, start: None }
+        PluginSort::ByPluginId {
+            order: Order::Ascending,
+            start: None,
+        }
     }
 }
 
 impl Default for UserSort {
     fn default() -> Self {
-        UserSort::ByUserId { order: Order::Ascending, start: None }
+        UserSort::ByUserId {
+            order: Order::Ascending,
+            start: None,
+        }
     }
 }

--- a/src/generated/plugins_generated.rs
+++ b/src/generated/plugins_generated.rs
@@ -5,6 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::*;
+use serde::{Deserialize, Serialize};
 
 /// Type of a plugin.
 #[derive(Debug, Eq, PartialEq, Copy, Serialize, Deserialize, Clone)]

--- a/src/generated/session_generated.rs
+++ b/src/generated/session_generated.rs
@@ -5,6 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::*;
+use serde::{Deserialize, Serialize};
 
 /// A challenge used for multi-factor authentication.
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]

--- a/src/generated/users_generated.rs
+++ b/src/generated/users_generated.rs
@@ -5,6 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::*;
+use serde::{Deserialize, Serialize};
 
 /// U2F recovery codes.
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]

--- a/src/generated/version_generated.rs
+++ b/src/generated/version_generated.rs
@@ -5,6 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::*;
+use serde::{Deserialize, Serialize};
 
 /// Server mode.
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,24 +55,7 @@
 //! [Fortanix SDKMS]: https://fortanix.com/products/sdkms/
 
 #[macro_use]
-extern crate serde_derive;
-extern crate rustc_serialize;
-extern crate serde;
-
-extern crate chrono;
-extern crate serde_json;
-extern crate uuid;
-
-#[macro_use]
 extern crate bitflags;
-
-extern crate hyper;
-
-#[cfg(feature = "hyper-native-tls")]
-extern crate hyper_native_tls;
-
-extern crate url;
-
 #[macro_use]
 extern crate log;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,5 +83,5 @@ mod client;
 mod generated;
 pub mod operations;
 
-pub use api_model::Error;
-pub use client::*;
+pub use crate::api_model::Error;
+pub use crate::client::*;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -116,7 +116,7 @@ macro_rules! singleton_backcompat {
             use ::serde;
             use std::result::Result;
             mod normal {
-                use ::serde;
+                use serde::{Deserialize, Serialize};
                 $(#[derive $derives])*
                 #[derive(Serialize, Deserialize)]
                 #[serde(rename_all = "UPPERCASE")]


### PR DESCRIPTION
- Make client Sync
- Update to 2018 edition
- Update uuid to 0.8, import serde_derive through serde
- Bump crate version to 0.3.0
- Mention new product name, DSM, in crate description