### PR TITLE
Remove dependency on hyper 0.10 and a few other old crates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,9 @@ jobs:
   allow_failures:
     - rust: nightly
   fast_finish: true
+before_install:
+  - cargo install cargo-audit
+script:
+  - cargo build --verbose
+  - cargo test --verbose
+  - cargo audit

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,19 +14,21 @@ categories = ["api-bindings"]
 edition = "2018"
 
 [features]
-default = ["hyper-native-tls"]
+default = ["native-tls"]
+native-tls = ["simple-hyper-client/native-tls", "tokio-native-tls"]
 
 [dependencies]
-chrono = "0.4"
+base64 = "0.13"
+bitflags = "1.0"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
+headers = "0.3.7"
+log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-hyper-native-tls = { version = "0.3", optional = true }
-hyper = "0.10"
-uuid = { version = "0.8", features = ["serde", "v4"] }
-rustc-serialize = "0.3"
-bitflags = "1.0"
+simple-hyper-client = "0.1.0"
+tokio-native-tls = { version = "0.3", optional = true }
 url = "1.7"
-log = "0.4"
+uuid = { version = "0.8", features = ["serde", "v4"] }
 
 [dev-dependencies]
 env_logger = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdkms"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Fortanix, Inc."]
 license = "MPL-2.0"
 description = """

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,12 +20,12 @@ native-tls = ["simple-hyper-client/native-tls", "tokio-native-tls"]
 [dependencies]
 base64 = "0.13"
 bitflags = "1.0"
-chrono = { version = "0.4", default-features = false, features = ["clock"] }
 headers = "0.3.7"
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 simple-hyper-client = "0.1.0"
+time = { version = "0.3", features = ["formatting", "macros", "parsing"] }
 tokio-native-tls = { version = "0.3", optional = true }
 url = "1.7"
 uuid = { version = "0.8", features = ["serde", "v4"] }

--- a/examples/approval_request.rs
+++ b/examples/approval_request.rs
@@ -1,4 +1,3 @@
-use rustc_serialize::base64::{ToBase64, STANDARD};
 use sdkms::api_model::*;
 use sdkms::{Error as SdkmsError, SdkmsClient};
 use std::{thread, time};
@@ -23,7 +22,7 @@ fn main() -> Result<(), SdkmsError> {
         deterministic_signature: None,
     };
     let sign_resp = sign(&client, &sign_req)?;
-    println!("Signature: {}", sign_resp.signature.to_base64(STANDARD));
+    println!("Signature: {}", base64::encode(sign_resp.signature));
     Ok(())
 }
 

--- a/examples/crud.rs
+++ b/examples/crud.rs
@@ -1,4 +1,3 @@
-use chrono::Local;
 use rand::prelude::*;
 use sdkms::api_model::*;
 use sdkms::{Error as SdkmsError, SdkmsClient};
@@ -51,7 +50,7 @@ fn sobject_to_string(s: &Sobject) -> String {
         s.name.as_ref().map(String::as_str).unwrap_or_default(),
         s.group_id.map_or("?".to_owned(), |kid| kid.to_string()),
         s.enabled,
-        s.created_at.to_datetime().with_timezone(&Local),
+        s.created_at.to_utc_datetime().unwrap(),
     )
 }
 

--- a/examples/plugin_approval_request.rs
+++ b/examples/plugin_approval_request.rs
@@ -1,4 +1,3 @@
-use rustc_serialize::base64::{ToBase64, STANDARD};
 use sdkms::api_model::*;
 use sdkms::{Error as SdkmsError, SdkmsClient};
 use serde::{Deserialize, Serialize};
@@ -30,7 +29,7 @@ fn main() -> Result<(), SdkmsError> {
     }
     let output = pa.result(&client)??;
     let output: SignResponse = serde_json::from_value(output)?;
-    println!("Signature: {}", output.signature.to_base64(STANDARD));
+    println!("Signature: {}", base64::encode(output.signature));
     Ok(())
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -140,7 +140,7 @@ impl SdkmsClientBuilder {
 /// which point you can call [`request_approval_to_encrypt()`]. There is an example of how to do this in
 /// [the repository](https://github.com/fortanix/sdkms-client-rust/blob/master/examples/approval_request.rs).
 ///
-/// [`simple_hyper_client::blocking::Client`]: TODO
+/// [`simple_hyper_client::blocking::Client`]: https://docs.rs/simple-hyper-client/0.1.0/simple_hyper_client/blocking/struct.Client.html
 /// [`tokio_native_tls::TlsConnector`]: https://docs.rs/tokio-native-tls/0.3.0/tokio_native_tls/struct.TlsConnector.html
 /// [`SdkmsClientBuilder::with_api_key()`]: ./struct.SdkmsClientBuilder.html#method.with_api_key
 /// [`SdkmsClient`]: ./struct.SdkmsClient.html

--- a/src/client.rs
+++ b/src/client.rs
@@ -7,11 +7,10 @@
 use crate::api_model::*;
 use crate::operations::*;
 
-use hyper::header::{Authorization, ContentType};
-use hyper::method::Method;
-use hyper::status::StatusCode;
-use hyper::Client as HyperClient;
-use rustc_serialize::base64::{ToBase64, STANDARD};
+use headers::{ContentType, HeaderMap, HeaderMapExt, HeaderValue};
+use simple_hyper_client::{Bytes, Method, StatusCode};
+use simple_hyper_client::blocking::Client as HttpClient;
+use simple_hyper_client::hyper::header::AUTHORIZATION;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -19,7 +18,6 @@ use std::fmt;
 use std::io::Read;
 use std::marker::PhantomData;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 pub const DEFAULT_API_ENDPOINT: &'static str = "https://sdkms.fortanix.com";
@@ -37,31 +35,30 @@ impl Auth {
     }
 
     fn from_user_pass<T: fmt::Display>(username: T, password: &str) -> Self {
-        Auth::Basic(
-            format!("{}:{}", username, password)
-                .as_bytes()
-                .to_base64(STANDARD),
-        )
+        Auth::Basic(base64::encode(format!("{}:{}", username, password)))
     }
 
-    fn format_header(&self) -> String {
-        match *self {
+    fn format_header(&self) -> HeaderValue {
+        let value = match *self {
             Auth::Basic(ref basic) => format!("Basic {}", basic),
             Auth::Bearer(ref bearer) => format!("Bearer {}", bearer),
-        }
+        };
+        let bytes = Bytes::from(value);
+        // TODO: return error instead of expect
+        HeaderValue::from_maybe_shared(bytes).expect("invalid characters in auth header")
     }
 }
 
 /// A builder for [`SdkmsClient`](./struct.SdkmsClient.html)
 pub struct SdkmsClientBuilder {
-    client: Option<Arc<HyperClient>>,
+    client: Option<HttpClient>,
     api_endpoint: Option<String>,
     auth: Option<Auth>,
 }
 
 impl SdkmsClientBuilder {
-    /// This can be used to customize the underlying HTTPS client if desired.
-    pub fn with_hyper_client(mut self, client: Arc<HyperClient>) -> Self {
+    /// This can be used to customize the underlying HTTP client if desired.
+    pub fn with_http_client(mut self, client: HttpClient) -> Self {
         self.client = Some(client);
         self
     }
@@ -86,22 +83,17 @@ impl SdkmsClientBuilder {
         let client = match self.client {
             Some(client) => client,
             None => {
-                #[cfg(feature = "hyper-native-tls")]
+                #[cfg(feature = "native-tls")]
                 {
-                    use hyper::client::Pool;
-                    use hyper::net::HttpsConnector;
-                    use hyper_native_tls::NativeTlsClient;
+                    use simple_hyper_client::HttpsConnector;
+                    use tokio_native_tls::native_tls::TlsConnector;
 
-                    let ssl = NativeTlsClient::new()?;
-                    let connector = HttpsConnector::new(ssl);
-                    let client = HyperClient::with_connector(Pool::with_connector(
-                        Default::default(),
-                        connector,
-                    ));
-                    Arc::new(client)
+                    let ssl = TlsConnector::new()?;
+                    let connector = HttpsConnector::new(ssl.into());
+                    HttpClient::with_connector(connector)
                 }
-                #[cfg(not(feature = "hyper-native-tls"))]
-                panic!("You should either provide a hyper Client or compile this crate with hyper-native-tls feature");
+                #[cfg(not(feature = "native-tls"))]
+                panic!("You should either provide an HTTP Client or compile this crate with native-tls feature");
             }
         };
 
@@ -120,7 +112,7 @@ impl SdkmsClientBuilder {
 /// A client session with SDKMS.
 ///
 /// REST APIs are exposed as methods on this type. Communication with SDKMS API endpoint is protected with TLS and this
-/// type uses [`hyper::Client`] along with [`hyper_native_tls::NativeTlsClient`] for HTTP/TLS.
+/// type uses [`simple_hyper_client::blocking::Client`] along with [`tokio_native_tls::TlsConnector`] for HTTP/TLS.
 ///
 /// When making crypto API calls using an API key, it is possible to pass the API key as an HTTP Basic Authorization
 /// header along with each request. This can be achieved by setting the API key using
@@ -148,8 +140,8 @@ impl SdkmsClientBuilder {
 /// which point you can call [`request_approval_to_encrypt()`]. There is an example of how to do this in
 /// [the repository](https://github.com/fortanix/sdkms-client-rust/blob/master/examples/approval_request.rs).
 ///
-/// [`hyper::Client`]: https://docs.rs/hyper/0.10/hyper/client/struct.Client.html
-/// [`hyper_native_tls::NativeTlsClient`]: https://docs.rs/hyper-native-tls/0.3/hyper_native_tls/struct.NativeTlsClient.html
+/// [`simple_hyper_client::blocking::Client`]: TODO
+/// [`tokio_native_tls::TlsConnector`]: https://docs.rs/tokio-native-tls/0.3.0/tokio_native_tls/struct.TlsConnector.html
 /// [`SdkmsClientBuilder::with_api_key()`]: ./struct.SdkmsClientBuilder.html#method.with_api_key
 /// [`SdkmsClient`]: ./struct.SdkmsClient.html
 /// [`encrypt()`]: #method.encrypt
@@ -157,7 +149,7 @@ impl SdkmsClientBuilder {
 pub struct SdkmsClient {
     auth: Option<Auth>,
     api_endpoint: String,
-    client: Arc<HyperClient>,
+    client: HttpClient,
     last_used: AtomicU64, // Time.0
     auth_response: Option<AuthResponse>,
 }
@@ -175,7 +167,7 @@ impl SdkmsClient {
         let auth_response: AuthResponse = json_request_with_auth(
             &self.client,
             &self.api_endpoint,
-            Method::Post,
+            Method::POST,
             "/sys/v1/session/auth",
             auth,
             None::<&()>,
@@ -250,7 +242,7 @@ impl Drop for SdkmsClient {
 impl SdkmsClient {
     pub fn terminate(&mut self) -> Result<()> {
         if let Some(Auth::Bearer(_)) = self.auth {
-            self.json_request(Method::Post, "/sys/v1/session/terminate", None::<&()>)?;
+            self.json_request(Method::POST, "/sys/v1/session/terminate", None::<&()>)?;
             self.auth = None;
         }
         Ok(())
@@ -329,7 +321,7 @@ impl<O: Operation> PendingApproval<O> {
             serde_json::from_value::<O::Output>(result.body).map_err(Error::EncoderError)
         } else {
             let msg: String = serde_json::from_value(result.body).map_err(Error::EncoderError)?;
-            Err(Error::from_status(StatusCode::from_u16(result.status), msg))
+            Err(Error::from_status(StatusCode::from_u16(result.status).unwrap(), msg))
         })
     }
 }
@@ -360,7 +352,7 @@ fn json_decode_reader<R: Read, T: for<'de> Deserialize<'de>>(rdr: &mut R) -> ser
 }
 
 fn json_request_with_auth<E, D>(
-    client: &HyperClient,
+    client: &HttpClient,
     api_endpoint: &str,
     method: Method,
     path: &str,
@@ -372,31 +364,33 @@ where
     D: for<'de> Deserialize<'de>,
 {
     let url = format!("{}{}", api_endpoint, path);
-    let encbody;
-    let mut req_builder = client.request(method.clone(), &url);
+    let mut req = client.request(method.clone(), &url)?;
+    let mut headers = HeaderMap::new();
     if let Some(auth) = auth {
-        req_builder = req_builder.header(Authorization(auth.format_header()));
+        headers.insert(AUTHORIZATION, auth.format_header());
     }
     if let Some(request_body) = body {
-        req_builder = req_builder.header(ContentType::json());
-        encbody = serde_json::to_string(request_body).map_err(Error::EncoderError)?;
-        req_builder = req_builder.body(encbody.as_bytes())
+        headers.typed_insert(ContentType::json());
+        let body = serde_json::to_string(request_body).map_err(Error::EncoderError)?;
+        req = req.body(body);
     }
-    match req_builder.send() {
+    req = req.headers(headers);
+    match req.send() {
         Err(e) => {
             info!("Error {} {}", method, url);
             Err(Error::NetworkError(e))
         }
-        Ok(ref mut res) if res.status.is_success() => {
-            info!("{} {} {}", res.status.to_u16(), method, url);
-            json_decode_reader(res).map_err(|err| Error::EncoderError(err))
+        Ok(ref mut res) if res.status().is_success() => {
+            info!("{} {} {}", res.status().as_u16(), method, url);
+            json_decode_reader(res.body_mut()).map_err(|err| Error::EncoderError(err))
         }
         Ok(ref mut res) => {
-            info!("{} {} {}", res.status.to_u16(), method, url);
+            info!("{} {} {}", res.status().as_u16(), method, url);
             let mut buffer = String::new();
-            res.read_to_string(&mut buffer)
+            res.body_mut()
+                .read_to_string(&mut buffer)
                 .map_err(|err| Error::IoError(err))?;
-            Err(Error::from_status(res.status, buffer))
+            Err(Error::from_status(res.status(), buffer))
         }
     }
 }

--- a/src/generated/accounts_generated.rs
+++ b/src/generated/accounts_generated.rs
@@ -445,7 +445,7 @@ impl Operation for OperationListAccounts {
     type Output = Vec<Account>;
 
     fn method() -> Method {
-        Method::Get
+        Method::GET
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/accounts?{q}", q = q.encode())
@@ -470,7 +470,7 @@ impl Operation for OperationGetAccount {
     type Output = Account;
 
     fn method() -> Method {
-        Method::Get
+        Method::GET
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/accounts/{id}?{q}", id = p.0, q = q.encode())
@@ -499,7 +499,7 @@ impl Operation for OperationCreateAccount {
     type Output = Account;
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/accounts")
@@ -528,7 +528,7 @@ impl Operation for OperationUpdateAccount {
     type Output = Account;
 
     fn method() -> Method {
-        Method::Patch
+        Method::PATCH
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/accounts/{id}", id = p.0)
@@ -558,7 +558,7 @@ impl Operation for OperationDeleteAccount {
     type Output = ();
 
     fn method() -> Method {
-        Method::Delete
+        Method::DELETE
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/accounts/{id}", id = p.0)
@@ -583,7 +583,7 @@ impl Operation for OperationAccountUsage {
     type Output = GetUsageResponse;
 
     fn method() -> Method {
-        Method::Get
+        Method::GET
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/accounts/{id}/usage?{q}", id = p.0, q = q.encode())

--- a/src/generated/approval_requests_generated.rs
+++ b/src/generated/approval_requests_generated.rs
@@ -125,7 +125,7 @@ impl Operation for OperationListApprovalRequests {
     type Output = Vec<ApprovalRequest>;
 
     fn method() -> Method {
-        Method::Get
+        Method::GET
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/approval_requests?{q}", q = q.encode())
@@ -153,7 +153,7 @@ impl Operation for OperationGetApprovalRequest {
     type Output = ApprovalRequest;
 
     fn method() -> Method {
-        Method::Get
+        Method::GET
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/approval_requests/{id}", id = p.0)
@@ -178,7 +178,7 @@ impl Operation for OperationCreateApprovalRequest {
     type Output = ApprovalRequest;
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/approval_requests")
@@ -200,7 +200,7 @@ impl Operation for OperationApproveRequest {
     type Output = ApprovalRequest;
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/approval_requests/{id}/approve", id = p.0)
@@ -222,7 +222,7 @@ impl Operation for OperationDenyRequest {
     type Output = ApprovalRequest;
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/approval_requests/{id}/deny", id = p.0)
@@ -247,7 +247,7 @@ impl Operation for OperationGetApprovalRequestResult {
     type Output = ApprovableResult;
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/approval_requests/{id}/result", id = p.0)
@@ -272,7 +272,7 @@ impl Operation for OperationDeleteApprovalRequest {
     type Output = ();
 
     fn method() -> Method {
-        Method::Delete
+        Method::DELETE
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/approval_requests/{id}", id = p.0)

--- a/src/generated/apps_generated.rs
+++ b/src/generated/apps_generated.rs
@@ -203,7 +203,7 @@ impl Operation for OperationListApps {
     type Output = Vec<App>;
 
     fn method() -> Method {
-        Method::Get
+        Method::GET
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/apps?{q}", q = q.encode())
@@ -228,7 +228,7 @@ impl Operation for OperationGetApp {
     type Output = App;
 
     fn method() -> Method {
-        Method::Get
+        Method::GET
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/apps/{id}?{q}", id = p.0, q = q.encode())
@@ -253,7 +253,7 @@ impl Operation for OperationCreateApp {
     type Output = App;
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/apps?{q}", q = q.encode())
@@ -275,7 +275,7 @@ impl Operation for OperationUpdateApp {
     type Output = App;
 
     fn method() -> Method {
-        Method::Patch
+        Method::PATCH
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/apps/{id}?{q}", id = p.0, q = q.encode())
@@ -302,7 +302,7 @@ impl Operation for OperationDeleteApp {
     type Output = ();
 
     fn method() -> Method {
-        Method::Delete
+        Method::DELETE
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/apps/{id}", id = p.0)
@@ -327,7 +327,7 @@ impl Operation for OperationResetAppSecret {
     type Output = App;
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!(
@@ -358,7 +358,7 @@ impl Operation for OperationGetAppCredential {
     type Output = AppCredentialResponse;
 
     fn method() -> Method {
-        Method::Get
+        Method::GET
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/apps/{id}/credential", id = p.0)

--- a/src/generated/crypto_generated.rs
+++ b/src/generated/crypto_generated.rs
@@ -481,7 +481,7 @@ impl Operation for OperationEncrypt {
     type Output = EncryptResponse;
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/crypto/v1/encrypt")
@@ -510,7 +510,7 @@ impl Operation for OperationEncryptInit {
     type Output = EncryptInitResponse;
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/crypto/v1/encrypt/init")
@@ -532,7 +532,7 @@ impl Operation for OperationEncryptUpdate {
     type Output = EncryptUpdateResponse;
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/crypto/v1/encrypt/update")
@@ -554,7 +554,7 @@ impl Operation for OperationEncryptFinal {
     type Output = EncryptFinalResponse;
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/crypto/v1/encrypt/final")
@@ -576,7 +576,7 @@ impl Operation for OperationDecrypt {
     type Output = DecryptResponse;
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/crypto/v1/decrypt")
@@ -605,7 +605,7 @@ impl Operation for OperationDecryptInit {
     type Output = DecryptInitResponse;
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/crypto/v1/decrypt/init")
@@ -627,7 +627,7 @@ impl Operation for OperationDecryptUpdate {
     type Output = DecryptUpdateResponse;
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/crypto/v1/decrypt/update")
@@ -649,7 +649,7 @@ impl Operation for OperationDecryptFinal {
     type Output = DecryptFinalResponse;
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/crypto/v1/decrypt/final")
@@ -671,7 +671,7 @@ impl Operation for OperationSign {
     type Output = SignResponse;
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/crypto/v1/sign")
@@ -700,7 +700,7 @@ impl Operation for OperationVerify {
     type Output = VerifyResponse;
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/crypto/v1/verify")
@@ -722,7 +722,7 @@ impl Operation for OperationWrap {
     type Output = WrapKeyResponse;
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/crypto/v1/wrapkey")
@@ -751,7 +751,7 @@ impl Operation for OperationUnwrap {
     type Output = Sobject;
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/crypto/v1/unwrapkey")
@@ -780,7 +780,7 @@ impl Operation for OperationMac {
     type Output = MacResponse;
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/crypto/v1/mac")
@@ -809,7 +809,7 @@ impl Operation for OperationMacVerify {
     type Output = VerifyResponse;
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/crypto/v1/macverify")
@@ -831,7 +831,7 @@ impl Operation for OperationDerive {
     type Output = Sobject;
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/crypto/v1/derive")
@@ -860,7 +860,7 @@ impl Operation for OperationAgree {
     type Output = Sobject;
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/crypto/v1/agree")
@@ -889,7 +889,7 @@ impl Operation for OperationCreateDigest {
     type Output = DigestResponse;
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/crypto/v1/digest")

--- a/src/generated/external_roles_generated.rs
+++ b/src/generated/external_roles_generated.rs
@@ -65,7 +65,7 @@ impl Operation for OperationListExternalRoles {
     type Output = Vec<ExternalRole>;
 
     fn method() -> Method {
-        Method::Get
+        Method::GET
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/external_roles?{q}", q = q.encode())
@@ -93,7 +93,7 @@ impl Operation for OperationGetExternalRole {
     type Output = ExternalRole;
 
     fn method() -> Method {
-        Method::Get
+        Method::GET
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/external_roles/{id}", id = p.0)
@@ -118,7 +118,7 @@ impl Operation for OperationCreateExternalRole {
     type Output = ExternalRole;
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/external_roles")
@@ -140,7 +140,7 @@ impl Operation for OperationSyncExternalRole {
     type Output = ExternalRole;
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/external_roles/{id}/sync", id = p.0)
@@ -165,7 +165,7 @@ impl Operation for OperationUpdateExternalRole {
     type Output = ExternalRole;
 
     fn method() -> Method {
-        Method::Patch
+        Method::PATCH
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/external_roles/{id}", id = p.0)
@@ -191,7 +191,7 @@ impl Operation for OperationDeleteExternalRole {
     type Output = ();
 
     fn method() -> Method {
-        Method::Delete
+        Method::DELETE
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/external_roles/{id}", id = p.0)

--- a/src/generated/groups_generated.rs
+++ b/src/generated/groups_generated.rs
@@ -39,7 +39,7 @@ impl Operation for OperationListGroups {
     type Output = Vec<Group>;
 
     fn method() -> Method {
-        Method::Get
+        Method::GET
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/groups")
@@ -64,7 +64,7 @@ impl Operation for OperationGetGroup {
     type Output = Group;
 
     fn method() -> Method {
-        Method::Get
+        Method::GET
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/groups/{id}", id = p.0)
@@ -89,7 +89,7 @@ impl Operation for OperationCreateGroup {
     type Output = Group;
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/groups")
@@ -111,7 +111,7 @@ impl Operation for OperationUpdateGroup {
     type Output = Group;
 
     fn method() -> Method {
-        Method::Patch
+        Method::PATCH
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/groups/{id}", id = p.0)
@@ -141,7 +141,7 @@ impl Operation for OperationDeleteGroup {
     type Output = ();
 
     fn method() -> Method {
-        Method::Delete
+        Method::DELETE
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/groups/{id}", id = p.0)

--- a/src/generated/keys_generated.rs
+++ b/src/generated/keys_generated.rs
@@ -182,7 +182,7 @@ impl Operation for OperationCreateSobject {
     type Output = Sobject;
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/crypto/v1/keys")
@@ -204,7 +204,7 @@ impl Operation for OperationImportSobject {
     type Output = Sobject;
 
     fn method() -> Method {
-        Method::Put
+        Method::PUT
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/crypto/v1/keys")
@@ -226,7 +226,7 @@ impl Operation for OperationUpdateSobject {
     type Output = Sobject;
 
     fn method() -> Method {
-        Method::Patch
+        Method::PATCH
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/crypto/v1/keys/{id}", id = p.0)
@@ -256,7 +256,7 @@ impl Operation for OperationDeleteSobject {
     type Output = ();
 
     fn method() -> Method {
-        Method::Delete
+        Method::DELETE
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/crypto/v1/keys/{id}", id = p.0)
@@ -288,7 +288,7 @@ impl Operation for OperationListSobjects {
     type Output = Vec<Sobject>;
 
     fn method() -> Method {
-        Method::Get
+        Method::GET
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/crypto/v1/keys?{q}", q = q.encode())
@@ -313,7 +313,7 @@ impl Operation for OperationGetSobject {
     type Output = Sobject;
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/crypto/v1/keys/info?{q}", q = q.encode())
@@ -339,7 +339,7 @@ impl Operation for OperationRemovePrivate {
     type Output = ();
 
     fn method() -> Method {
-        Method::Delete
+        Method::DELETE
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/crypto/v1/keys/{id}/private", id = p.0)
@@ -364,7 +364,7 @@ impl Operation for OperationExportSobject {
     type Output = Sobject;
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/crypto/v1/keys/export")
@@ -393,7 +393,7 @@ impl Operation for OperationDigestSobject {
     type Output = ObjectDigestResponse;
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/crypto/v1/keys/digest")
@@ -415,7 +415,7 @@ impl Operation for OperationPersistTransientKey {
     type Output = Sobject;
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/crypto/v1/keys/persist")
@@ -437,7 +437,7 @@ impl Operation for OperationRotateSobject {
     type Output = Sobject;
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/crypto/v1/keys/rekey")
@@ -459,7 +459,7 @@ impl Operation for OperationActivateSobject {
     type Output = ();
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/crypto/v1/keys/{id}/activate", id = p.0)
@@ -484,7 +484,7 @@ impl Operation for OperationRevokeSobject {
     type Output = ();
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/crypto/v1/keys/{id}/revoke", id = p.0)
@@ -506,7 +506,7 @@ impl Operation for OperationBatchSign {
     type Output = Vec<BatchResponseItem<SignResponse>>;
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/crypto/v1/keys/batch/sign")
@@ -538,7 +538,7 @@ impl Operation for OperationBatchVerify {
     type Output = Vec<BatchResponseItem<VerifyResponse>>;
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/crypto/v1/keys/batch/verify")

--- a/src/generated/mod.rs
+++ b/src/generated/mod.rs
@@ -7,7 +7,7 @@
 use crate::api_model::*;
 use crate::client::{PendingApproval, Result, SdkmsClient};
 use crate::operations::*;
-use hyper::method::Method;
+use simple_hyper_client::Method;
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 use uuid::Uuid;

--- a/src/generated/plugins_generated.rs
+++ b/src/generated/plugins_generated.rs
@@ -152,7 +152,7 @@ impl Operation for OperationListPlugins {
     type Output = Vec<Plugin>;
 
     fn method() -> Method {
-        Method::Get
+        Method::GET
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/plugins?{q}", q = q.encode())
@@ -177,7 +177,7 @@ impl Operation for OperationGetPlugin {
     type Output = Plugin;
 
     fn method() -> Method {
-        Method::Get
+        Method::GET
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/plugins/{id}", id = p.0)
@@ -202,7 +202,7 @@ impl Operation for OperationCreatePlugin {
     type Output = Plugin;
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/plugins")
@@ -231,7 +231,7 @@ impl Operation for OperationUpdatePlugin {
     type Output = Plugin;
 
     fn method() -> Method {
-        Method::Patch
+        Method::PATCH
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/plugins/{id}", id = p.0)
@@ -261,7 +261,7 @@ impl Operation for OperationDeletePlugin {
     type Output = ();
 
     fn method() -> Method {
-        Method::Delete
+        Method::DELETE
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/plugins/{id}", id = p.0)
@@ -286,7 +286,7 @@ impl Operation for OperationInvokePlugin {
     type Output = PluginOutput;
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/plugins/{id}", id = p.0)

--- a/src/generated/session_generated.rs
+++ b/src/generated/session_generated.rs
@@ -59,7 +59,7 @@ impl Operation for OperationRefresh {
     type Output = ();
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/session/refresh")
@@ -84,7 +84,7 @@ impl Operation for OperationSelectAccount {
     type Output = SelectAccountResponse;
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/session/select_account")
@@ -106,7 +106,7 @@ impl Operation for OperationU2fAuth {
     type Output = ();
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/session/auth/2fa/u2f")
@@ -128,7 +128,7 @@ impl Operation for OperationRecoveryCodeAuth {
     type Output = ();
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/session/auth/2fa/recovery_code")
@@ -150,7 +150,7 @@ impl Operation for OperationConfig2faAuth {
     type Output = Config2faAuthResponse;
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/session/config_2fa/auth")
@@ -172,7 +172,7 @@ impl Operation for OperationConfig2faTerminate {
     type Output = ();
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/session/config_2fa/terminate")
@@ -197,7 +197,7 @@ impl Operation for OperationU2fNewChallenge {
     type Output = MfaChallengeResponse;
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/session/config_2fa/new_challenge")

--- a/src/generated/users_generated.rs
+++ b/src/generated/users_generated.rs
@@ -214,7 +214,7 @@ impl Operation for OperationSignupUser {
     type Output = User;
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/users")
@@ -236,7 +236,7 @@ impl Operation for OperationListUsers {
     type Output = Vec<User>;
 
     fn method() -> Method {
-        Method::Get
+        Method::GET
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/users?{q}", q = q.encode())
@@ -261,7 +261,7 @@ impl Operation for OperationGetUser {
     type Output = User;
 
     fn method() -> Method {
-        Method::Get
+        Method::GET
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/users/{id}", id = p.0)
@@ -286,7 +286,7 @@ impl Operation for OperationUpdateUser {
     type Output = User;
 
     fn method() -> Method {
-        Method::Patch
+        Method::PATCH
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/users/{id}", id = p.0)
@@ -308,7 +308,7 @@ impl Operation for OperationResetPassword {
     type Output = ();
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/users/{id}/reset_password", id = p.0)
@@ -330,7 +330,7 @@ impl Operation for OperationForgotPassword {
     type Output = ();
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/users/forgot_password")
@@ -352,7 +352,7 @@ impl Operation for OperationInviteUser {
     type Output = User;
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/users/invite")
@@ -374,7 +374,7 @@ impl Operation for OperationProcessInvite {
     type Output = ();
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/users/process_invite")
@@ -396,7 +396,7 @@ impl Operation for OperationResendInvite {
     type Output = ();
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/users/{id}/resend_invite", id = p.0)
@@ -421,7 +421,7 @@ impl Operation for OperationDeleteUser {
     type Output = ();
 
     fn method() -> Method {
-        Method::Delete
+        Method::DELETE
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/users")
@@ -446,7 +446,7 @@ impl Operation for OperationChangePassword {
     type Output = ();
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/users/change_password")
@@ -468,7 +468,7 @@ impl Operation for OperationGetUserAccounts {
     type Output = HashMap<Uuid, UserAccountFlags>;
 
     fn method() -> Method {
-        Method::Get
+        Method::GET
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/users/accounts")
@@ -493,7 +493,7 @@ impl Operation for OperationDeleteUserAccount {
     type Output = ();
 
     fn method() -> Method {
-        Method::Delete
+        Method::DELETE
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/users/{id}/accounts", id = p.0)
@@ -518,7 +518,7 @@ impl Operation for OperationGenerateRecoveryCodes {
     type Output = RecoveryCodes;
 
     fn method() -> Method {
-        Method::Post
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/users/generate_recovery_codes")

--- a/src/generated/version_generated.rs
+++ b/src/generated/version_generated.rs
@@ -37,7 +37,7 @@ impl Operation for OperationVersion {
     type Output = VersionResponse;
 
     fn method() -> Method {
-        Method::Get
+        Method::GET
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/version")

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use hyper::method::Method;
+use simple_hyper_client::Method;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt::Write;


### PR DESCRIPTION
- Remove dependency on `hyper` 0.10 and use `simple-hyper-client` instead
- Remove dependency on `rustc-serialize` and use `base64` instead
- Remove dependency on `chrono` and use `time` instead
- Run `cargo audit` in CI
- Bump up version from 0.3.0 to 0.4.0 due to breaking changes in API (i.e. `Time` and `SdkmsClientBuilder`)