### PR TITLE
Updated Blocking client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ edition = "2018"
 [features]
 default = ["native-tls"]
 native-tls = ["simple-hyper-client/native-tls", "tokio-native-tls"]
+async = []
 
 [dependencies]
 base64 = "0.13"
@@ -29,6 +30,7 @@ time = { version = "0.3", features = ["formatting", "macros", "parsing"] }
 tokio-native-tls = { version = "0.3", optional = true }
 url = "1.7"
 uuid = { version = "0.8", features = ["serde", "v4"] }
+strum = { version = "0.21", features = ["derive"] }
 
 [dev-dependencies]
 env_logger = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ edition = "2018"
 [features]
 default = ["native-tls"]
 native-tls = ["simple-hyper-client/native-tls", "tokio-native-tls"]
-async = []
 
 [dependencies]
 base64 = "0.13"

--- a/examples/crud.rs
+++ b/examples/crud.rs
@@ -25,14 +25,14 @@ fn main() -> Result<(), SdkmsError> {
     println!("Created sobject: {}", sobject_to_string(&sobject));
 
     let query_params = ListSobjectsParams {
-        sort: SobjectSort::ByName {
+        sort: Some(SobjectSort::ByName {
             order: Order::Ascending,
             start: None,
-        },
+        }),
         ..Default::default()
     };
     let keys = client.list_sobjects(Some(&query_params))?;
-    println!("\n\nListing all sobjects ({}):", keys.len());
+    println!("\n\nListing all sobjects ({}):", keys.items.len());
     for key in keys {
         println!("{}", sobject_to_string(&key));
     }

--- a/examples/encrypt_decrypt.rs
+++ b/examples/encrypt_decrypt.rs
@@ -31,6 +31,7 @@ fn main() -> Result<(), SdkmsError> {
         alg: None,
         ad: None,
         tag: None,
+        masked: None,
     };
     let decrypt_resp = client.decrypt(&decrypt_req)?;
     let plain = String::from_utf8(decrypt_resp.plain.into()).expect("valid utf8");

--- a/examples/get_user.rs
+++ b/examples/get_user.rs
@@ -10,7 +10,7 @@ const MY_ACCT_ID: &'static str = "b6080ec0-df2e-...";
 fn main() -> Result<(), SdkmsError> {
     env_logger::init();
 
-    let mut client = SdkmsClient::builder()
+    let client = SdkmsClient::builder()
         .with_api_endpoint("https://sdkms.fortanix.com")
         .build()?
         .authenticate_user(MY_USERNAME, MY_PASSWORD)?;

--- a/examples/session.rs
+++ b/examples/session.rs
@@ -7,7 +7,7 @@ const KEY_NAME: &'static str = "RSA Key 1";
 fn main() -> Result<(), SdkmsError> {
     env_logger::init();
 
-    let mut client = SdkmsClient::builder()
+    let client = SdkmsClient::builder()
         .with_api_endpoint("https://sdkms.fortanix.com")
         .build()?
         .authenticate_with_api_key(MY_API_KEY)?;

--- a/examples/session.rs
+++ b/examples/session.rs
@@ -31,6 +31,7 @@ fn main() -> Result<(), SdkmsError> {
         alg: None,
         ad: None,
         tag: None,
+        masked: None,
     };
     let decrypt_resp = client.decrypt(&decrypt_req)?;
     let plain = String::from_utf8(decrypt_resp.plain.into()).expect("valid utf8");

--- a/src/api_model.rs
+++ b/src/api_model.rs
@@ -103,7 +103,7 @@ impl AsRef<[u8]> for Blob {
 
 impl ToString for Blob {
     fn to_string(&self) -> String {
-        self.to_string()
+        String::from_utf8(self.0.clone()).unwrap()
     }
 }
 
@@ -532,7 +532,7 @@ impl fmt::Display for PluginVersion {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct CustomMetadata(pub HashMap<String, String>);
 
 impl Serialize for CustomMetadata {
@@ -739,10 +739,6 @@ impl AppRole {
             AppRole::Admin => AccountRole::AdminApp,
             AppRole::Crypto => AccountRole::CryptoApp,
         }
-    }
-
-    pub fn backcompat_deserialize_opt<'a, D: Deserializer<'a>>(deserializer: D) -> Result<Self, D::Error> {
-        Ok(Option::<AppRole>::deserialize(deserializer)?.unwrap_or_default())
     }
 }
 

--- a/src/client/common.rs
+++ b/src/client/common.rs
@@ -6,10 +6,10 @@
 
 use crate::api_model::*;
 use crate::operations::*;
-use headers::{HeaderValue};
-use simple_hyper_client::{Bytes, StatusCode};
+use headers::HeaderValue;
+use serde::Deserialize;
 use simple_hyper_client::blocking::Client as HttpClient;
-use serde::{Deserialize};
+use simple_hyper_client::{Bytes, StatusCode};
 use uuid::Uuid;
 
 use std::fmt;
@@ -240,7 +240,9 @@ impl<O: Operation> Clone for PendingApproval<O> {
     }
 }
 
-pub(super) fn json_decode_reader<R: Read, T: for<'de> Deserialize<'de>>(rdr: &mut R) -> serde_json::Result<T> {
+pub(super) fn json_decode_reader<R: Read, T: for<'de> Deserialize<'de>>(
+    rdr: &mut R,
+) -> serde_json::Result<T> {
     match serde_json::from_reader(rdr) {
         // When the body of the response is empty, attempt to deserialize null value instead
         Err(ref e) if e.is_eof() && e.line() == 1 && e.column() == 0 => {

--- a/src/client/common.rs
+++ b/src/client/common.rs
@@ -6,12 +6,10 @@
 
 use crate::api_model::*;
 use crate::operations::*;
-
-use headers::{ContentType, HeaderMap, HeaderMapExt, HeaderValue};
-use serde::{Deserialize, Serialize};
+use headers::{HeaderValue};
+use simple_hyper_client::{Bytes, StatusCode};
 use simple_hyper_client::blocking::Client as HttpClient;
-use simple_hyper_client::hyper::header::AUTHORIZATION;
-use simple_hyper_client::{Bytes, Method, StatusCode};
+use serde::{Deserialize};
 use uuid::Uuid;
 
 use std::fmt;
@@ -244,16 +242,6 @@ impl<O: Operation> Clone for PendingApproval<O> {
 
 pub(super) fn json_decode_reader<R: Read, T: for<'de> Deserialize<'de>>(rdr: &mut R) -> serde_json::Result<T> {
     match serde_json::from_reader(rdr) {
-        // When the body of the response is empty, attempt to deserialize null value instead
-        Err(ref e) if e.is_eof() && e.line() == 1 && e.column() == 0 => {
-            serde_json::from_value(serde_json::Value::Null)
-        }
-        v => v,
-    }
-}
-
-pub(super) fn json_decode_bytes<T: for<'de> Deserialize<'de>>(buff: &mut Bytes) -> serde_json::Result<T> {
-    match serde_json::from_slice(buff) {
         // When the body of the response is empty, attempt to deserialize null value instead
         Err(ref e) if e.is_eof() && e.line() == 1 && e.column() == 0 => {
             serde_json::from_value(serde_json::Value::Null)

--- a/src/client/impl_async.rs
+++ b/src/client/impl_async.rs
@@ -1,0 +1,156 @@
+use crate::api_model::*;
+use crate::operations::*;
+use super::common::*;
+
+use super::SdkmsClient;
+use std::fmt;
+use std::io::Read;
+use std::marker::PhantomData;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+use super::common::*;
+use headers::HeaderMapExt;
+use headers::{ContentType, HeaderMap};
+use simple_hyper_client::to_bytes;
+use uuid::Uuid;
+use simple_hyper_client::Client as HttpClient;
+use simple_hyper_client::{Bytes, Method, StatusCode};
+use simple_hyper_client::hyper::header::AUTHORIZATION;
+use serde::{Deserialize, Serialize};
+
+impl SdkmsClient {    
+    // pub async fn terminate(&mut self) -> Result<()> {
+    //     if let Some(Auth::Bearer(_)) = self.auth {
+    //         self.json_request(Method::POST, "/sys/v1/session/terminate", None::<&()>).await?;
+    //         self.auth = None;
+    //     }
+    //     Ok(())
+    // }
+
+    pub async fn invoke_plugin_nice<I, O>(&self, id: &Uuid, req: &I) -> Result<O>
+    where
+        I: Serialize,
+        O: for<'de> Deserialize<'de>,
+    {
+        let req = serde_json::to_value(req)?;
+        let output = self.execute::<OperationInvokePlugin>(&req, (id,), None).await?;
+        Ok(serde_json::from_value(output)?)
+    }
+
+    pub async fn execute<O: Operation>(
+        &self,
+        body: &O::Body,
+        p: <O::PathParams as TupleRef<'_>>::Ref,
+        q: Option<&O::QueryParams>,
+    ) -> Result<O::Output> {
+        self.json_request(O::method(), &O::path(p, q), O::to_body(body).as_ref()).await
+    }
+
+    pub async fn request_approval<O: Operation>(
+        &self,
+        body: &O::Body,
+        p: <O::PathParams as TupleRef<'_>>::Ref,
+        q: Option<&O::QueryParams>,
+        description: Option<String>,
+    ) -> Result<PendingApproval<O>> {
+        let request = self.create_approval_request(&ApprovalRequestRequest {
+            operation: Some(O::path(p, q)),
+            method: Some(format!("{}", O::method())),
+            body: O::to_body(body),
+            description,
+        }).await?;
+        Ok(PendingApproval::from_request_id(request.request_id))
+    }
+    
+    async fn old_auth(&self, auth: Option<&Auth>) -> Result<Self> {
+        let auth_response: AuthResponse = json_request_with_auth(
+            &self.client,
+            &self.api_endpoint,
+            Method::POST,
+            "/sys/v1/session/auth",
+            auth,
+            None::<&()>,
+        ).await?;
+        Ok(SdkmsClient {
+            client: self.client.clone(),
+            api_endpoint: self.api_endpoint.clone(),
+            auth: Some(Auth::Bearer(auth_response.access_token.clone())),
+            last_used: AtomicU64::new(now().0),
+            auth_response: Some(auth_response),
+        })
+    }
+
+    pub async fn authenticate_with_api_key(&self, api_key: &str) -> Result<Self> {
+        self.old_auth(Some(Auth::from_api_key(api_key)).as_ref()).await
+    }
+
+    pub async fn authenticate_with_cert(&self, app_id: Option<&Uuid>) -> Result<Self> {
+        self.old_auth(app_id.map(|id| Auth::from_user_pass(id, "")).as_ref()).await
+    }
+
+    pub async fn authenticate_app(&self, app_id: &Uuid, app_secret: &str) -> Result<Self> {
+        self.old_auth(Some(Auth::from_user_pass(app_id, app_secret)).as_ref()).await
+    }
+
+    pub async fn authenticate_user(&self, email: &str, password: &str) -> Result<Self> {
+        self.old_auth(Some(Auth::from_user_pass(email, password)).as_ref()).await
+    }
+
+    async fn json_request<E, D>(&self, method: Method, uri: &str, req: Option<&E>) -> Result<D>
+    where
+        E: Serialize,
+        D: for<'de> Deserialize<'de>,
+    {
+        let Self {
+            ref client,
+            ref api_endpoint,
+            ref auth,
+            ..
+        } = *self;
+        let result = json_request_with_auth(client, api_endpoint, method, uri, auth.as_ref(), req).await?;
+        self.last_used.store(now().0, Ordering::Relaxed);
+        Ok(result)
+    }
+}
+
+async fn json_request_with_auth<E, D>(
+    client: &HttpClient,
+    api_endpoint: &str,
+    method: Method,
+    path: &str,
+    auth: Option<&Auth>,
+    body: Option<&E>,
+) -> Result<D>
+where
+    E: Serialize,
+    D: for<'de> Deserialize<'de>,
+{
+    let url = format!("{}{}", api_endpoint, path);
+    let mut req = client.request(method.clone(), &url)?;
+    let mut headers = HeaderMap::new();
+    if let Some(auth) = auth {
+        headers.insert(AUTHORIZATION, auth.format_header());
+    }
+    if let Some(request_body) = body {
+        headers.typed_insert(ContentType::json());
+        let body = serde_json::to_string(request_body).map_err(Error::EncoderError)?;
+        req = req.body(body);
+    }
+    req = req.headers(headers);
+    match req.send().await {
+        Err(e) => {
+            info!("Error {} {}", method, url);
+            Err(Error::NetworkError(e))
+        }
+        Ok(ref mut res) if res.status().is_success() => {
+            info!("{} {} {}", res.status().as_u16(), method, url);
+            //TODO Remove Unwrap
+            json_decode_bytes(&mut to_bytes(res.body_mut()).await.expect("Could not convert body to bytes")).map_err(|err| Error::EncoderError(err))
+        }
+        Ok(ref mut res) => {
+            info!("{} {} {}", res.status().as_u16(), method, url);
+            let buffer = String::from_utf8(to_bytes(res.body_mut()).await.expect("Could not convert to Bytes").to_vec()).unwrap();
+            Err(Error::from_status(res.status(), buffer))
+        }
+    }
+}

--- a/src/client/impl_blocking.rs
+++ b/src/client/impl_blocking.rs
@@ -1,0 +1,154 @@
+use crate::api_model::*;
+use crate::operations::*;
+
+use super::SdkmsClient;
+use super::common::*;
+use headers::{ContentType, HeaderMap, HeaderMapExt};
+use simple_hyper_client::hyper::header::AUTHORIZATION;
+use simple_hyper_client::blocking::Client as HttpClient;
+use serde::{Deserialize, Serialize};
+use simple_hyper_client::{Method};
+use std::sync::atomic::{AtomicU64, Ordering};
+use uuid::Uuid;
+use std::io::Read;
+
+
+impl SdkmsClient {
+    fn authenticate_client(&self, auth: Option<&Auth>) -> Result<Self> {
+        let auth_response: AuthResponse = json_request_with_auth(
+            &self.client,
+            &self.api_endpoint,
+            Method::POST,
+            "/sys/v1/session/auth",
+            auth,
+            None::<&()>,
+        )?;
+        Ok(SdkmsClient {
+            client: self.client.clone(),
+            api_endpoint: self.api_endpoint.clone(),
+            auth: Some(Auth::Bearer(auth_response.access_token.clone())),
+            last_used: AtomicU64::new(now().0),
+            auth_response: Some(auth_response),
+        })
+    }
+    
+    pub fn authenticate_with_api_key(&self, api_key: &str) -> Result<Self> {
+        self.authenticate_client(Some(Auth::from_api_key(api_key)).as_ref())
+    }
+    
+    pub fn authenticate_with_cert(&self, app_id: Option<&Uuid>) -> Result<Self> {
+        self.authenticate_client(app_id.map(|id| Auth::from_user_pass(id, "")).as_ref())
+    }
+    
+    pub fn authenticate_app(&self, app_id: &Uuid, app_secret: &str) -> Result<Self> {
+        self.authenticate_client(Some(Auth::from_user_pass(app_id, app_secret)).as_ref())
+    }
+    
+    pub fn authenticate_user(&self, email: &str, password: &str) -> Result<Self> {
+        self.authenticate_client(Some(Auth::from_user_pass(email, password)).as_ref())
+    }
+    
+    fn json_request<E, D>(&self, method: Method, uri: &str, req: Option<&E>) -> Result<D>
+        where
+            E: Serialize,
+            D: for<'de> Deserialize<'de>,
+    {
+        let Self {
+            ref client,
+            ref api_endpoint,
+            ref auth,
+            ..
+        } = *self;
+        let result = json_request_with_auth(client, api_endpoint, method, uri, auth.as_ref(), req)?;
+        self.last_used.store(now().0, Ordering::Relaxed);
+        Ok(result)
+    }
+    
+    pub fn terminate_client(&mut self) -> Result<()> {
+        if let Some(Auth::Bearer(_)) = self.auth {
+            self.json_request(Method::POST, "/sys/v1/session/terminate", None::<&()>)?;
+            self.auth = None;
+        }
+        Ok(())
+    }
+    
+    pub fn invoke_plugin_nice<I, O>(&self, id: &Uuid, req: &I) -> Result<O>
+    where
+        I: Serialize,
+        O: for<'de> Deserialize<'de>,
+    {
+        let req = serde_json::to_value(req)?;
+        let output = self.execute::<OperationInvokePlugin>(&req, (id,), None)?;
+        Ok(serde_json::from_value(output)?)
+    }
+    
+    pub fn execute<O: Operation>(
+        &self,
+        body: &O::Body,
+        p: <O::PathParams as TupleRef>::Ref,
+        q: Option<&O::QueryParams>,
+    ) -> Result<O::Output> {
+        self.json_request(O::method(), &O::path(p, q), O::to_body(body).as_ref())
+    }
+    
+    pub fn request_approval<O: Operation>(
+        &self,
+        body: &O::Body,
+        p: <O::PathParams as TupleRef>::Ref,
+        q: Option<&O::QueryParams>,
+        description: Option<String>,
+    ) -> Result<PendingApproval<O>> {
+        let request = self.create_approval_request(&ApprovalRequestRequest {
+            operation: Some(O::path(p, q)),
+            method: Some(format!("{}", O::method())),
+            body: O::to_body(body),
+            description,
+        })?;
+        Ok(PendingApproval::from_request_id(request.request_id))
+    }
+}
+
+fn json_request_with_auth<E, D>(
+    client: &HttpClient,
+    api_endpoint: &str,
+    method: Method,
+    path: &str,
+    auth: Option<&Auth>,
+    body: Option<&E>,
+) -> Result<D>
+where
+    E: Serialize,
+    D: for<'de> Deserialize<'de>,
+{
+    let url = format!("{}{}", api_endpoint, path);
+    let mut req = client.request(method.clone(), &url)?;
+    let mut headers = HeaderMap::new();
+    if let Some(auth) = auth {
+        headers.insert(AUTHORIZATION, auth.format_header());
+    }
+    if let Some(request_body) = body {
+        headers.typed_insert(ContentType::json());
+        let body = serde_json::to_string(request_body).map_err(Error::EncoderError)?;
+        req = req.body(body);
+    }
+    // dbg!(&headers);
+    req = req.headers(headers);
+    match req.send() {
+        Err(e) => {
+            info!("Error {} {}", method, url);
+            Err(Error::NetworkError(e))
+        }
+        Ok(ref mut res) if res.status().is_success() => {
+            info!("{} {} {}", res.status().as_u16(), method, url);
+            json_decode_reader(res.body_mut()).map_err(|err| Error::EncoderError(err))
+        }
+        Ok(ref mut res) => {
+            info!("{} {} {}", res.status().as_u16(), method, url);
+            let mut buffer = String::new();
+            res.body_mut()
+                .read_to_string(&mut buffer)
+                .map_err(|err| Error::IoError(err))?;
+            Err(Error::from_status(res.status(), buffer))
+        }
+    }
+}

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,0 +1,8 @@
+mod common;
+
+#[cfg(feature = "async")]
+mod impl_async;
+#[cfg(not(feature = "async"))]
+pub mod impl_blocking;
+
+pub use self::common::{SdkmsClientBuilder, SdkmsClient, PendingApproval, Result};

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -2,4 +2,4 @@ mod common;
 
 pub mod impl_blocking;
 
-pub use self::common::{SdkmsClientBuilder, SdkmsClient, PendingApproval, Result};
+pub use self::common::{PendingApproval, Result, SdkmsClient, SdkmsClientBuilder};

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,8 +1,5 @@
 mod common;
 
-#[cfg(feature = "async")]
-mod impl_async;
-#[cfg(not(feature = "async"))]
 pub mod impl_blocking;
 
 pub use self::common::{SdkmsClientBuilder, SdkmsClient, PendingApproval, Result};

--- a/src/generated/accounts_generated.rs
+++ b/src/generated/accounts_generated.rs
@@ -26,9 +26,9 @@ pub struct Account {
     #[serde(default)]
     pub custom_logo: Option<Blob>,
     #[serde(default)]
-    pub custom_metadata: Option<HashMap<String,String>>,
+    pub custom_metadata: Option<HashMap<String, String>>,
     #[serde(default)]
-    pub custom_metadata_attributes: Option<HashMap<String,CustomAttributeSearchMetadata>>,
+    pub custom_metadata_attributes: Option<HashMap<String, CustomAttributeSearchMetadata>>,
     #[serde(default)]
     pub description: Option<String>,
     #[serde(default)]
@@ -42,7 +42,7 @@ pub struct Account {
     pub key_metadata_policy: Option<KeyMetadataPolicy>,
     #[serde(default)]
     pub log_bad_requests: Option<bool>,
-    pub logging_configs: HashMap<Uuid,LoggingConfig>,
+    pub logging_configs: HashMap<Uuid, LoggingConfig>,
     #[serde(default)]
     pub max_app: Option<u32>,
     #[serde(default)]
@@ -74,7 +74,7 @@ pub struct Account {
     #[serde(default)]
     pub trial_expires_at: Option<Time>,
     #[serde(default)]
-    pub workspace_cse_config: Option<WorkspaceCseConfig>
+    pub workspace_cse_config: Option<WorkspaceCseConfig>,
 }
 
 /// Account approval policy.
@@ -87,7 +87,7 @@ pub struct AccountApprovalPolicy {
     /// When this is true, changes to the account cryptographic policy requires approval.
     pub protect_cryptographic_policy: Option<bool>,
     /// When this is true, changes to logging configuration require approval.
-    pub protect_logging_config: Option<bool>
+    pub protect_logging_config: Option<bool>,
 }
 
 #[derive(Default, Debug, Serialize, Deserialize, Clone)]
@@ -111,9 +111,9 @@ pub struct AccountRequest {
     #[serde(default)]
     pub custom_logo: Option<Blob>,
     #[serde(default)]
-    pub custom_metadata: Option<HashMap<String,String>>,
+    pub custom_metadata: Option<HashMap<String, String>>,
     #[serde(default)]
-    pub custom_metadata_attributes: Option<HashMap<String,CustomAttributeSearchMetadata>>,
+    pub custom_metadata_attributes: Option<HashMap<String, CustomAttributeSearchMetadata>>,
     #[serde(default)]
     pub del_ldap: Option<HashSet<Uuid>>,
     #[serde(default)]
@@ -129,9 +129,9 @@ pub struct AccountRequest {
     #[serde(default)]
     pub log_bad_requests: Option<bool>,
     #[serde(default)]
-    pub mod_ldap: Option<HashMap<Uuid,AuthConfigLdap>>,
+    pub mod_ldap: Option<HashMap<Uuid, AuthConfigLdap>>,
     #[serde(default)]
-    pub mod_logging_configs: Option<HashMap<Uuid,LoggingConfigRequest>>,
+    pub mod_logging_configs: Option<HashMap<Uuid, LoggingConfigRequest>>,
     #[serde(default)]
     pub name: Option<String>,
     #[serde(default)]
@@ -149,7 +149,7 @@ pub struct AccountRequest {
     #[serde(default)]
     pub subscription: Option<Subscription>,
     #[serde(default)]
-    pub workspace_cse_config: Option<Option<WorkspaceCseConfig>>
+    pub workspace_cse_config: Option<Option<WorkspaceCseConfig>>,
 }
 
 #[derive(PartialEq, Eq, Debug, Default, Serialize, Deserialize, Clone)]
@@ -160,7 +160,7 @@ pub struct AppCreditsUsage {
     pub accelerator: u32,
     pub secrets_management: u32,
     pub aws_cloud_accounts: u32,
-    pub azure_cloud_accounts: u32
+    pub azure_cloud_accounts: u32,
 }
 
 /// Account authentication settings.
@@ -173,11 +173,11 @@ pub struct AuthConfig {
     #[serde(default)]
     pub oauth: Option<AuthConfigOauth>,
     #[serde(default)]
-    pub ldap: HashMap<Uuid,AuthConfigLdap>,
+    pub ldap: HashMap<Uuid, AuthConfigLdap>,
     #[serde(default)]
     pub signed_jwt: Option<AuthConfigSignedJwt>,
     #[serde(default)]
-    pub vcd: Option<AuthConfigVcd>
+    pub vcd: Option<AuthConfigVcd>,
 }
 
 /// OAuth single sign-on authentication settings.
@@ -192,21 +192,21 @@ pub struct AuthConfigOauth {
     pub idp_requires_basic_auth: bool,
     pub tls: TlsConfig,
     pub client_id: String,
-    pub client_secret: String
+    pub client_secret: String,
 }
 
 /// Password authentication settings.
 #[derive(PartialEq, Eq, Debug, Default, Serialize, Deserialize, Clone)]
 pub struct AuthConfigPassword {
     pub require_2fa: bool,
-    pub administrators_only: bool
+    pub administrators_only: bool,
 }
 
 /// Signed JWT authentication settings.
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
 pub struct AuthConfigSignedJwt {
     pub valid_issuers: HashSet<String>,
-    pub signing_keys: JwtSigningKeys
+    pub signing_keys: JwtSigningKeys,
 }
 
 /// Vcd single sign-on authentication settings.
@@ -215,7 +215,7 @@ pub struct AuthConfigVcd {
     pub idp_name: String,
     pub idp_authorization_endpoint: String,
     pub org: String,
-    pub tls: TlsConfig
+    pub tls: TlsConfig,
 }
 
 #[derive(Serialize, Deserialize, Clone, Default)]
@@ -223,7 +223,7 @@ pub struct CountParams {
     pub range_from: Option<u64>,
     pub range_to: Option<u64>,
     pub detailed_usage: Option<bool>,
-    pub saas_full_usage: Option<bool>
+    pub saas_full_usage: Option<bool>,
 }
 
 impl UrlEncode for CountParams {
@@ -245,7 +245,7 @@ impl UrlEncode for CountParams {
 
 #[derive(Debug, Eq, PartialEq, Copy, Serialize, Deserialize, Clone)]
 pub struct CustomAttributeSearchMetadata {
-    pub suggest: bool
+    pub suggest: bool,
 }
 
 /// Custom subscription type
@@ -260,7 +260,7 @@ pub struct CustomSubscriptionType {
     pub count_transient_ops: Option<bool>,
     pub package_name: Option<String>,
     pub features: Option<SubscriptionFeatures>,
-    pub add_ons: Option<HashMap<String,String>>
+    pub add_ons: Option<HashMap<String, String>>,
 }
 
 #[derive(Eq, PartialEq, Debug, Serialize, Deserialize, Clone)]
@@ -270,12 +270,12 @@ pub struct FreemiumSubscriptionType {
     pub max_hsmg: Option<u32>,
     pub max_operation: Option<u64>,
     pub max_tokenization_operation: Option<u64>,
-    pub max_plugin: Option<u32>
+    pub max_plugin: Option<u32>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Default)]
 pub struct GetAccountParams {
-    pub with_totals: bool
+    pub with_totals: bool,
 }
 
 impl UrlEncode for GetAccountParams {
@@ -312,9 +312,9 @@ pub struct GetUsageResponse {
     #[serde(default)]
     pub hsm_gateway: Option<u32>,
     #[serde(default)]
-    pub operation_top_app: Option<HashMap<String,u64>>,
+    pub operation_top_app: Option<HashMap<String, u64>>,
     #[serde(default)]
-    pub operation_top_sobject: Option<HashMap<String,u64>>
+    pub operation_top_sobject: Option<HashMap<String, u64>>,
 }
 
 /// A Google service account key object. See https://cloud.google.com/video-intelligence/docs/common/auth.
@@ -326,35 +326,23 @@ pub struct GoogleServiceAccountKey {
     pub private_key_id: String,
     #[serde(default)]
     pub private_key: Option<String>,
-    pub client_email: String
+    pub client_email: String,
 }
 
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum LoggingConfig {
-    Splunk (
-        SplunkLoggingConfig
-    ),
-    Stackdriver (
-        StackdriverLoggingConfig
-    ),
-    Syslog (
-        SyslogLoggingConfig
-    )
+    Splunk(SplunkLoggingConfig),
+    Stackdriver(StackdriverLoggingConfig),
+    Syslog(SyslogLoggingConfig),
 }
 
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum LoggingConfigRequest {
-    Splunk (
-        SplunkLoggingConfigRequest
-    ),
-    Stackdriver (
-        StackdriverLoggingConfigRequest
-    ),
-    Syslog (
-        SyslogLoggingConfigRequest
-    )
+    Splunk(SplunkLoggingConfigRequest),
+    Stackdriver(StackdriverLoggingConfigRequest),
+    Syslog(SyslogLoggingConfigRequest),
 }
 
 /// Notification preferences.
@@ -363,7 +351,7 @@ pub enum NotificationPref {
     None,
     Email,
     Phone,
-    Both
+    Both,
 }
 
 /// Counts of objects of various types in an account.
@@ -374,7 +362,7 @@ pub struct ObjectCounts {
     pub users: u64,
     pub plugins: u64,
     pub sobjects: u64,
-    pub child_accounts: u64
+    pub child_accounts: u64,
 }
 
 /// Reseller subscription type
@@ -388,8 +376,8 @@ pub struct ResellerSubscriptionType {
     pub max_tenant_operation: Option<u64>,
     pub package_name: Option<String>,
     pub features: Option<SubscriptionFeatures>,
-    pub add_ons: Option<HashMap<String,String>>,
-    pub tenant_features: Option<SubscriptionFeatures>
+    pub add_ons: Option<HashMap<String, String>>,
+    pub tenant_features: Option<SubscriptionFeatures>,
 }
 
 /// Splunk logging configuration.
@@ -399,7 +387,7 @@ pub struct SplunkLoggingConfig {
     pub host: String,
     pub port: u16,
     pub index: String,
-    pub tls: TlsConfig
+    pub tls: TlsConfig,
 }
 
 #[derive(Default, PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
@@ -417,7 +405,7 @@ pub struct SplunkLoggingConfigRequest {
     #[serde(default)]
     pub token: Option<String>,
     #[serde(default)]
-    pub tls: Option<TlsConfig>
+    pub tls: Option<TlsConfig>,
 }
 
 /// Stackdriver logging configuration.
@@ -426,7 +414,7 @@ pub struct StackdriverLoggingConfig {
     pub enabled: bool,
     /// The log ID that will recieve the log items (see https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry).
     pub log_id: String,
-    pub service_account_key: GoogleServiceAccountKey
+    pub service_account_key: GoogleServiceAccountKey,
 }
 
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
@@ -434,7 +422,7 @@ pub struct StackdriverLoggingConfigRequest {
     pub enabled: Option<bool>,
     /// The log ID that will recieve the log items (see https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry).
     pub log_id: Option<String>,
-    pub service_account_key: Option<GoogleServiceAccountKey>
+    pub service_account_key: Option<GoogleServiceAccountKey>,
 }
 
 #[derive(PartialEq, Eq, Debug, Default, Serialize, Deserialize, Clone)]
@@ -442,7 +430,7 @@ pub struct Subscription {
     #[serde(default)]
     pub memo: Option<String>,
     #[serde(flatten)]
-    pub subscription_type: SubscriptionType
+    pub subscription_type: SubscriptionType,
 }
 
 /// A request to update subscription type.
@@ -452,13 +440,13 @@ pub struct SubscriptionChangeRequest {
     #[serde(default)]
     pub contact: Option<String>,
     #[serde(default)]
-    pub comment: Option<String>
+    pub comment: Option<String>,
 }
 
 /// Features in subscription
 pub use self::subscription_features::SubscriptionFeatures;
 pub mod subscription_features {
-    bitflags_set!{
+    bitflags_set! {
         pub struct SubscriptionFeatures: u64 {
             const TOKENIZATION = 0x0000000000000001;
             const HMG = 0x0000000000000002;
@@ -473,27 +461,13 @@ pub mod subscription_features {
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum SubscriptionType {
-    Trial {
-        expires_at: Option<Time>
-    },
-    Standard {
-
-    },
-    Enterprise {
-
-    },
-    Custom (
-        Box<CustomSubscriptionType>
-    ),
-    Freemium (
-        Box<FreemiumSubscriptionType>
-    ),
-    OnPrem {
-
-    },
-    Reseller (
-        Box<ResellerSubscriptionType>
-    )
+    Trial { expires_at: Option<Time> },
+    Standard {},
+    Enterprise {},
+    Custom(Box<CustomSubscriptionType>),
+    Freemium(Box<FreemiumSubscriptionType>),
+    OnPrem {},
+    Reseller(Box<ResellerSubscriptionType>),
 }
 
 #[derive(Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize, Clone)]
@@ -506,7 +480,7 @@ pub enum SyslogFacility {
     Local4,
     Local5,
     Local6,
-    Local7
+    Local7,
 }
 
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
@@ -515,7 +489,7 @@ pub struct SyslogLoggingConfig {
     pub host: String,
     pub port: u16,
     pub tls: TlsConfig,
-    pub facility: SyslogFacility
+    pub facility: SyslogFacility,
 }
 
 #[derive(Default, PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
@@ -529,7 +503,7 @@ pub struct SyslogLoggingConfigRequest {
     #[serde(default)]
     pub tls: Option<TlsConfig>,
     #[serde(default)]
-    pub facility: Option<SyslogFacility>
+    pub facility: Option<SyslogFacility>,
 }
 
 /// These settings will allow the service to validate the Google-issued
@@ -553,7 +527,7 @@ pub struct WorkspaceCseAuthorizationProvider {
     pub valid_issuers: HashSet<String>,
     /// Acceptable values for the `aud` (audience) field used in Google's
     /// authorization tokens
-    pub valid_audiences: HashSet<String>
+    pub valid_audiences: HashSet<String>,
 }
 
 /// Workspace CSE API settings. Specifying these settings enables the CSE APIs
@@ -568,7 +542,7 @@ pub struct WorkspaceCseConfig {
     /// One or more authorization providers used to validate authorization
     /// tokens. Different Workspace applications might require different
     /// authorization settings.
-    pub authorization_providers: Vec<WorkspaceCseAuthorizationProvider>
+    pub authorization_providers: Vec<WorkspaceCseAuthorizationProvider>,
 }
 
 /// An identity provider trusted to authenticate users for Workspace CSE APIs
@@ -583,7 +557,7 @@ pub struct WorkspaceCseIdentityProvider {
     pub valid_issuers: HashSet<String>,
     /// Acceptable values for the `aud` (audience) field used in authentication
     /// tokens
-    pub valid_audiences: HashSet<String>
+    pub valid_audiences: HashSet<String>,
 }
 
 pub struct OperationAccountUsage;
@@ -600,10 +574,17 @@ impl Operation for OperationAccountUsage {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/accounts/{id}/usage?{q}", id = p.0, q = q.encode())
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
+        None
+    }
+}
 
 impl SdkmsClient {
-    pub fn account_usage(&self, id: &Uuid, query_params: Option<&CountParams>) -> Result<GetUsageResponse> {
+    pub fn account_usage(
+        &self,
+        id: &Uuid,
+        query_params: Option<&CountParams>,
+    ) -> Result<GetUsageResponse> {
         self.execute::<OperationAccountUsage>(&(), (id,), query_params)
     }
 }
@@ -629,8 +610,10 @@ impl SdkmsClient {
         self.execute::<OperationCreateAccount>(req, (), None)
     }
     pub fn request_approval_to_create_account(
-        &self, req: &AccountRequest,
-        description: Option<String>) -> Result<PendingApproval<OperationCreateAccount>> {
+        &self,
+        req: &AccountRequest,
+        description: Option<String>,
+    ) -> Result<PendingApproval<OperationCreateAccount>> {
         self.request_approval::<OperationCreateAccount>(req, (), None, description)
     }
 }
@@ -649,7 +632,10 @@ impl Operation for OperationDeleteAccount {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/accounts/{id}", id = p.0)
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
+        None
+    }
+}
 
 impl SdkmsClient {
     pub fn delete_account(&self, id: &Uuid) -> Result<()> {
@@ -671,10 +657,17 @@ impl Operation for OperationGetAccount {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/accounts/{id}?{q}", id = p.0, q = q.encode())
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
+        None
+    }
+}
 
 impl SdkmsClient {
-    pub fn get_account(&self, id: &Uuid, query_params: Option<&GetAccountParams>) -> Result<Account> {
+    pub fn get_account(
+        &self,
+        id: &Uuid,
+        query_params: Option<&GetAccountParams>,
+    ) -> Result<Account> {
         self.execute::<OperationGetAccount>(&(), (id,), query_params)
     }
 }
@@ -693,7 +686,10 @@ impl Operation for OperationListAccounts {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/accounts?{q}", q = q.encode())
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
+        None
+    }
+}
 
 impl SdkmsClient {
     pub fn list_accounts(&self, query_params: Option<&GetAccountParams>) -> Result<Vec<Account>> {
@@ -722,9 +718,11 @@ impl SdkmsClient {
         self.execute::<OperationUpdateAccount>(req, (id,), None)
     }
     pub fn request_approval_to_update_account(
-        &self, id: &Uuid, req: &AccountRequest,
-        description: Option<String>) -> Result<PendingApproval<OperationUpdateAccount>> {
+        &self,
+        id: &Uuid,
+        req: &AccountRequest,
+        description: Option<String>,
+    ) -> Result<PendingApproval<OperationUpdateAccount>> {
         self.request_approval::<OperationUpdateAccount>(req, (id,), None, description)
     }
 }
-

--- a/src/generated/accounts_generated.rs
+++ b/src/generated/accounts_generated.rs
@@ -5,189 +5,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::*;
-use serde::{Deserialize, Serialize};
-
-/// Type of subscription.
-#[derive(Copy, PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "snake_case")]
-pub enum SubscriptionType {
-    Trial {
-        expires_at: Option<Time>,
-    },
-    Standard,
-    Enterprise,
-    Custom {
-        max_plugin: Option<u32>,
-        max_operation: Option<u64>,
-    },
-    OnPrem,
-    Reseller {
-        max_plugin: Option<u32>,
-        max_operation: Option<u64>,
-        max_tenant: Option<u32>,
-        max_tenant_plugin: Option<u32>,
-        max_tenant_operation: Option<u64>,
-    },
-}
-
-/// A request to update subscription type.
-#[derive(Eq, PartialEq, Debug, Serialize, Deserialize, Clone)]
-pub struct SubscriptionChangeRequest {
-    pub subscription: SubscriptionType,
-    #[serde(default)]
-    pub contact: Option<String>,
-    #[serde(default)]
-    pub comment: Option<String>,
-}
-
-/// Notification preferences.
-#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
-pub enum NotificationPref {
-    None,
-    Email,
-    Phone,
-    Both,
-}
-
-/// Password authentication settings.
-#[derive(PartialEq, Eq, Debug, Default, Serialize, Deserialize, Clone)]
-pub struct AuthConfigPassword {
-    pub require_2fa: bool,
-    pub administrators_only: bool,
-}
-
-/// OAuth single sign-on authentication settings.
-#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
-pub struct AuthConfigOauth {
-    pub idp_name: String,
-    pub idp_icon_url: String,
-    pub idp_authorization_endpoint: String,
-    pub idp_token_endpoint: String,
-    #[serde(default)]
-    pub idp_userinfo_endpoint: Option<String>,
-    pub idp_requires_basic_auth: bool,
-    pub tls: TlsConfig,
-    pub client_id: String,
-    pub client_secret: String,
-}
-
-/// Credentials used by the service to authenticate itself to an LDAP server.
-#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
-pub struct LdapServiceAccount {
-    pub dn: String,
-    pub password: String,
-}
-
-/// Distinguished Name (DN) resolution method. Given a user's email address, a DN resolution method
-/// is used to find the user's DN in an LDAP directory.
-#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "kebab-case", tag = "method")]
-pub enum LdapDnResolution {
-    /// Transform the user email through a pattern to derive the DN.
-    Construct {
-        /// For example: "example.com" => "uid={},ou=users,dc=example,dc=com".
-        domain_format: HashMap<String, String>,
-    },
-    /// Search the directory using the LDAP `mail` attribute matching user's email.
-    SearchByMail,
-    /// Use email in place of DN. This method works with Active Directory if the userPrincipalName
-    /// attribute is set for the user. https://docs.microsoft.com/en-us/windows/desktop/ad/naming-properties
-    #[serde(rename = "upn")]
-    UserPrincipalName,
-}
-
-/// LDAP authorization settings.
-#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
-pub struct LdapAuthorizationConfig {
-    /// Number of seconds after which the authorization should be checked again.
-    pub valid_for: u64,
-    /// Distinguished name of an LDAP group. If specified, account members must be a member of this
-    /// LDAP group to be able to select the accout.
-    pub require_role: Option<String>,
-}
-
-/// LDAP authentication settings.
-#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
-pub struct AuthConfigLdap {
-    pub name: String,
-    pub icon_url: String,
-    pub ldap_url: String,
-    pub dn_resolution: LdapDnResolution,
-    pub tls: TlsConfig,
-    #[serde(default)]
-    pub base_dn: Option<String>,
-    #[serde(default)]
-    pub user_object_class: Option<String>,
-    #[serde(default)]
-    pub service_account: Option<LdapServiceAccount>,
-    #[serde(default)]
-    pub authorization: Option<LdapAuthorizationConfig>,
-}
-
-/// Signed JWT authentication settings.
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
-pub struct AuthConfigSignedJwt {
-    pub valid_issuers: HashSet<String>,
-    pub signing_keys: JwtSigningKeys,
-}
-
-/// Counts of objects of various types in an account.
-#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
-pub struct ObjectCounts {
-    pub groups: u64,
-    pub apps: u64,
-    pub users: u64,
-    pub plugins: u64,
-    pub sobjects: u64,
-}
-
-/// CA settings.
-#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "snake_case")]
-pub enum CaConfig {
-    CaSet(CaSet),
-    Pinned(Vec<Blob>),
-}
-
-/// Predefined CA sets.
-#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "snake_case")]
-pub enum CaSet {
-    GlobalRoots,
-}
-
-/// TLS settings.
-#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "snake_case", tag = "mode")]
-pub enum TlsConfig {
-    Disabled,
-    Opportunistic,
-    Required {
-        validate_hostname: bool,
-        ca: CaConfig,
-    },
-}
-
-/// Account approval policy.
-#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
-pub struct AccountApprovalPolicy {
-    pub policy: ApprovalPolicy,
-    pub manage_groups: bool,
-}
-
-/// Syslog facility.
-#[derive(Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
-pub enum SyslogFacility {
-    User,
-    Local0,
-    Local1,
-    Local2,
-    Local3,
-    Local4,
-    Local5,
-    Local6,
-    Local7,
-}
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Account {
@@ -199,19 +16,33 @@ pub struct Account {
     #[serde(default)]
     pub auth_config: Option<AuthConfig>,
     #[serde(default)]
+    pub client_configurations: Option<ClientConfigurations>,
+    #[serde(default)]
     pub country: Option<String>,
     #[serde(default)]
     pub created_at: Option<Time>,
     #[serde(default)]
+    pub cryptographic_policy: Option<CryptographicPolicy>,
+    #[serde(default)]
     pub custom_logo: Option<Blob>,
     #[serde(default)]
-    pub custom_metadata: Option<HashMap<String, String>>,
+    pub custom_metadata: Option<HashMap<String,String>>,
+    #[serde(default)]
+    pub custom_metadata_attributes: Option<HashMap<String,CustomAttributeSearchMetadata>>,
     #[serde(default)]
     pub description: Option<String>,
+    #[serde(default)]
+    pub disabled_at: Option<Time>,
     pub enabled: bool,
     #[serde(default)]
     pub initial_purchase_at: Option<Time>,
-    pub logging_configs: HashMap<Uuid, LoggingConfig>,
+    #[serde(default)]
+    pub key_history_policy: Option<KeyHistoryPolicy>,
+    #[serde(default)]
+    pub key_metadata_policy: Option<KeyMetadataPolicy>,
+    #[serde(default)]
+    pub log_bad_requests: Option<bool>,
+    pub logging_configs: HashMap<Uuid,LoggingConfig>,
     #[serde(default)]
     pub max_app: Option<u32>,
     #[serde(default)]
@@ -237,11 +68,26 @@ pub struct Account {
     pub phone: Option<String>,
     #[serde(default)]
     pub plugin_enabled: Option<bool>,
-    pub subscription: SubscriptionType,
+    pub subscription: Subscription,
     #[serde(default)]
     pub totals: Option<ObjectCounts>,
     #[serde(default)]
     pub trial_expires_at: Option<Time>,
+    #[serde(default)]
+    pub workspace_cse_config: Option<WorkspaceCseConfig>
+}
+
+/// Account approval policy.
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
+pub struct AccountApprovalPolicy {
+    pub policy: QuorumPolicy,
+    pub manage_groups: bool,
+    /// When this is true, changes to the account authentication methods require approval.
+    pub protect_authentication_methods: Option<bool>,
+    /// When this is true, changes to the account cryptographic policy requires approval.
+    pub protect_cryptographic_policy: Option<bool>,
+    /// When this is true, changes to logging configuration require approval.
+    pub protect_logging_config: Option<bool>
 }
 
 #[derive(Default, Debug, Serialize, Deserialize, Clone)]
@@ -257,11 +103,17 @@ pub struct AccountRequest {
     #[serde(default)]
     pub auth_config: Option<AuthConfig>,
     #[serde(default)]
+    pub client_configurations: Option<ClientConfigurationsRequest>,
+    #[serde(default)]
     pub country: Option<String>,
+    #[serde(default)]
+    pub cryptographic_policy: Option<Option<CryptographicPolicy>>,
     #[serde(default)]
     pub custom_logo: Option<Blob>,
     #[serde(default)]
-    pub custom_metadata: Option<HashMap<String, String>>,
+    pub custom_metadata: Option<HashMap<String,String>>,
+    #[serde(default)]
+    pub custom_metadata_attributes: Option<HashMap<String,CustomAttributeSearchMetadata>>,
     #[serde(default)]
     pub del_ldap: Option<HashSet<Uuid>>,
     #[serde(default)]
@@ -271,9 +123,15 @@ pub struct AccountRequest {
     #[serde(default)]
     pub enabled: Option<bool>,
     #[serde(default)]
-    pub mod_ldap: Option<HashMap<Uuid, AuthConfigLdap>>,
+    pub key_history_policy: Option<Option<KeyHistoryPolicy>>,
     #[serde(default)]
-    pub mod_logging_configs: Option<HashMap<Uuid, LoggingConfigRequest>>,
+    pub key_metadata_policy: Option<Option<KeyMetadataPolicy>>,
+    #[serde(default)]
+    pub log_bad_requests: Option<bool>,
+    #[serde(default)]
+    pub mod_ldap: Option<HashMap<Uuid,AuthConfigLdap>>,
+    #[serde(default)]
+    pub mod_logging_configs: Option<HashMap<Uuid,LoggingConfigRequest>>,
     #[serde(default)]
     pub name: Option<String>,
     #[serde(default)]
@@ -289,62 +147,174 @@ pub struct AccountRequest {
     #[serde(default)]
     pub plugin_enabled: Option<bool>,
     #[serde(default)]
-    pub subscription: Option<SubscriptionType>,
+    pub subscription: Option<Subscription>,
+    #[serde(default)]
+    pub workspace_cse_config: Option<Option<WorkspaceCseConfig>>
 }
 
-#[derive(Serialize, Deserialize, Clone, Default)]
-pub struct GetAccountParams {
-    pub with_totals: bool,
+#[derive(PartialEq, Eq, Debug, Default, Serialize, Deserialize, Clone)]
+pub struct AppCreditsUsage {
+    pub generic: u32,
+    pub tokenization: u32,
+    pub tep: u32,
+    pub accelerator: u32,
+    pub secrets_management: u32,
+    pub aws_cloud_accounts: u32,
+    pub azure_cloud_accounts: u32
 }
 
-impl UrlEncode for GetAccountParams {
-    fn url_encode(&self, m: &mut HashMap<&'static str, String>) {
-        m.insert("with_totals", self.with_totals.to_string());
-    }
+/// Account authentication settings.
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+pub struct AuthConfig {
+    #[serde(default)]
+    pub password: Option<AuthConfigPassword>,
+    #[serde(default)]
+    pub saml: Option<String>,
+    #[serde(default)]
+    pub oauth: Option<AuthConfigOauth>,
+    #[serde(default)]
+    pub ldap: HashMap<Uuid,AuthConfigLdap>,
+    #[serde(default)]
+    pub signed_jwt: Option<AuthConfigSignedJwt>,
+    #[serde(default)]
+    pub vcd: Option<AuthConfigVcd>
+}
+
+/// OAuth single sign-on authentication settings.
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+pub struct AuthConfigOauth {
+    pub idp_name: String,
+    pub idp_icon_url: String,
+    pub idp_authorization_endpoint: String,
+    pub idp_token_endpoint: String,
+    #[serde(default)]
+    pub idp_userinfo_endpoint: Option<String>,
+    pub idp_requires_basic_auth: bool,
+    pub tls: TlsConfig,
+    pub client_id: String,
+    pub client_secret: String
+}
+
+/// Password authentication settings.
+#[derive(PartialEq, Eq, Debug, Default, Serialize, Deserialize, Clone)]
+pub struct AuthConfigPassword {
+    pub require_2fa: bool,
+    pub administrators_only: bool
+}
+
+/// Signed JWT authentication settings.
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
+pub struct AuthConfigSignedJwt {
+    pub valid_issuers: HashSet<String>,
+    pub signing_keys: JwtSigningKeys
+}
+
+/// Vcd single sign-on authentication settings.
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+pub struct AuthConfigVcd {
+    pub idp_name: String,
+    pub idp_authorization_endpoint: String,
+    pub org: String,
+    pub tls: TlsConfig
 }
 
 #[derive(Serialize, Deserialize, Clone, Default)]
 pub struct CountParams {
     pub range_from: Option<u64>,
     pub range_to: Option<u64>,
+    pub detailed_usage: Option<bool>,
+    pub saas_full_usage: Option<bool>
 }
 
 impl UrlEncode for CountParams {
-    fn url_encode(&self, m: &mut HashMap<&'static str, String>) {
+    fn url_encode(&self, m: &mut HashMap<String, String>) {
         if let Some(ref v) = self.range_from {
-            m.insert("range_from", v.to_string());
+            m.insert("range_from".to_string(), v.to_string());
         }
         if let Some(ref v) = self.range_to {
-            m.insert("range_to", v.to_string());
+            m.insert("range_to".to_string(), v.to_string());
+        }
+        if let Some(ref v) = self.detailed_usage {
+            m.insert("detailed_usage".to_string(), v.to_string());
+        }
+        if let Some(ref v) = self.saas_full_usage {
+            m.insert("saas_full_usage".to_string(), v.to_string());
         }
     }
 }
 
-/// Splunk logging configuration.
-#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
-pub struct SplunkLoggingConfig {
-    pub enabled: bool,
-    pub host: String,
-    pub port: u16,
-    pub index: String,
-    pub tls: TlsConfig,
+#[derive(Debug, Eq, PartialEq, Copy, Serialize, Deserialize, Clone)]
+pub struct CustomAttributeSearchMetadata {
+    pub suggest: bool
 }
 
-/// Stackdriver logging configuration.
-#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
-pub struct StackdriverLoggingConfig {
-    pub enabled: bool,
-    /// The log ID that will recieve the log items (see https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry).
-    pub log_id: String,
-    pub service_account_key: GoogleServiceAccountKey,
+/// Custom subscription type
+#[derive(Eq, PartialEq, Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "snake_case")]
+pub struct CustomSubscriptionType {
+    pub max_plugin: Option<u32>,
+    pub max_app: Option<u32>,
+    pub max_hsmg: Option<u32>,
+    pub max_operation: Option<u64>,
+    pub max_tokenization_operation: Option<u64>,
+    pub count_transient_ops: Option<bool>,
+    pub package_name: Option<String>,
+    pub features: Option<SubscriptionFeatures>,
+    pub add_ons: Option<HashMap<String,String>>
 }
 
-#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
-pub struct StackdriverLoggingConfigRequest {
-    pub enabled: Option<bool>,
-    /// The log ID that will recieve the log items (see https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry).
-    pub log_id: Option<String>,
-    pub service_account_key: Option<GoogleServiceAccountKey>,
+#[derive(Eq, PartialEq, Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "snake_case")]
+pub struct FreemiumSubscriptionType {
+    pub max_app: Option<u32>,
+    pub max_hsmg: Option<u32>,
+    pub max_operation: Option<u64>,
+    pub max_tokenization_operation: Option<u64>,
+    pub max_plugin: Option<u32>
+}
+
+#[derive(Serialize, Deserialize, Clone, Default)]
+pub struct GetAccountParams {
+    pub with_totals: bool
+}
+
+impl UrlEncode for GetAccountParams {
+    fn url_encode(&self, m: &mut HashMap<String, String>) {
+        m.insert("with_totals".to_string(), self.with_totals.to_string());
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Default, Serialize, Deserialize, Clone)]
+pub struct GetUsageResponse {
+    pub num_operations: u64,
+    #[serde(default)]
+    pub encryption_operations: Option<u64>,
+    #[serde(default)]
+    pub decryption_operations: Option<u64>,
+    #[serde(default)]
+    pub sign_operations: Option<u64>,
+    #[serde(default)]
+    pub verify_operations: Option<u64>,
+    #[serde(default)]
+    pub tokenization_operations: Option<u64>,
+    #[serde(default)]
+    pub detokenization_operations: Option<u64>,
+    #[serde(default)]
+    pub secrets_operations: Option<u64>,
+    #[serde(default)]
+    pub plugin_invoke_operations: Option<u64>,
+    #[serde(default)]
+    pub apps: Option<AppCreditsUsage>,
+    #[serde(default)]
+    pub plugin: Option<u32>,
+    #[serde(default)]
+    pub sobjects: Option<u64>,
+    #[serde(default)]
+    pub hsm_gateway: Option<u32>,
+    #[serde(default)]
+    pub operation_top_app: Option<HashMap<String,u64>>,
+    #[serde(default)]
+    pub operation_top_sobject: Option<HashMap<String,u64>>
 }
 
 /// A Google service account key object. See https://cloud.google.com/video-intelligence/docs/common/auth.
@@ -356,7 +326,80 @@ pub struct GoogleServiceAccountKey {
     pub private_key_id: String,
     #[serde(default)]
     pub private_key: Option<String>,
-    pub client_email: String,
+    pub client_email: String
+}
+
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum LoggingConfig {
+    Splunk (
+        SplunkLoggingConfig
+    ),
+    Stackdriver (
+        StackdriverLoggingConfig
+    ),
+    Syslog (
+        SyslogLoggingConfig
+    )
+}
+
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum LoggingConfigRequest {
+    Splunk (
+        SplunkLoggingConfigRequest
+    ),
+    Stackdriver (
+        StackdriverLoggingConfigRequest
+    ),
+    Syslog (
+        SyslogLoggingConfigRequest
+    )
+}
+
+/// Notification preferences.
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+pub enum NotificationPref {
+    None,
+    Email,
+    Phone,
+    Both
+}
+
+/// Counts of objects of various types in an account.
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+pub struct ObjectCounts {
+    pub groups: u64,
+    pub apps: u64,
+    pub users: u64,
+    pub plugins: u64,
+    pub sobjects: u64,
+    pub child_accounts: u64
+}
+
+/// Reseller subscription type
+#[derive(Eq, PartialEq, Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "snake_case")]
+pub struct ResellerSubscriptionType {
+    pub max_plugin: Option<u32>,
+    pub max_operation: Option<u64>,
+    pub max_tenant: Option<u32>,
+    pub max_tenant_plugin: Option<u32>,
+    pub max_tenant_operation: Option<u64>,
+    pub package_name: Option<String>,
+    pub features: Option<SubscriptionFeatures>,
+    pub add_ons: Option<HashMap<String,String>>,
+    pub tenant_features: Option<SubscriptionFeatures>
+}
+
+/// Splunk logging configuration.
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+pub struct SplunkLoggingConfig {
+    pub enabled: bool,
+    pub host: String,
+    pub port: u16,
+    pub index: String,
+    pub tls: TlsConfig
 }
 
 #[derive(Default, PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
@@ -374,7 +417,96 @@ pub struct SplunkLoggingConfigRequest {
     #[serde(default)]
     pub token: Option<String>,
     #[serde(default)]
-    pub tls: Option<TlsConfig>,
+    pub tls: Option<TlsConfig>
+}
+
+/// Stackdriver logging configuration.
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+pub struct StackdriverLoggingConfig {
+    pub enabled: bool,
+    /// The log ID that will recieve the log items (see https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry).
+    pub log_id: String,
+    pub service_account_key: GoogleServiceAccountKey
+}
+
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+pub struct StackdriverLoggingConfigRequest {
+    pub enabled: Option<bool>,
+    /// The log ID that will recieve the log items (see https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry).
+    pub log_id: Option<String>,
+    pub service_account_key: Option<GoogleServiceAccountKey>
+}
+
+#[derive(PartialEq, Eq, Debug, Default, Serialize, Deserialize, Clone)]
+pub struct Subscription {
+    #[serde(default)]
+    pub memo: Option<String>,
+    #[serde(flatten)]
+    pub subscription_type: SubscriptionType
+}
+
+/// A request to update subscription type.
+#[derive(Eq, PartialEq, Debug, Serialize, Deserialize, Clone)]
+pub struct SubscriptionChangeRequest {
+    pub subscription: Subscription,
+    #[serde(default)]
+    pub contact: Option<String>,
+    #[serde(default)]
+    pub comment: Option<String>
+}
+
+/// Features in subscription
+pub use self::subscription_features::SubscriptionFeatures;
+pub mod subscription_features {
+    bitflags_set!{
+        pub struct SubscriptionFeatures: u64 {
+            const TOKENIZATION = 0x0000000000000001;
+            const HMG = 0x0000000000000002;
+            const AWSBYOK = 0x0000000000000004;
+            const AZUREBYOK = 0x0000000000000008;
+            const GCPBYOK = 0x0000000000000010;
+        }
+    }
+}
+
+/// Type of subscription.
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum SubscriptionType {
+    Trial {
+        expires_at: Option<Time>
+    },
+    Standard {
+
+    },
+    Enterprise {
+
+    },
+    Custom (
+        Box<CustomSubscriptionType>
+    ),
+    Freemium (
+        Box<FreemiumSubscriptionType>
+    ),
+    OnPrem {
+
+    },
+    Reseller (
+        Box<ResellerSubscriptionType>
+    )
+}
+
+#[derive(Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize, Clone)]
+pub enum SyslogFacility {
+    User,
+    Local0,
+    Local1,
+    Local2,
+    Local3,
+    Local4,
+    Local5,
+    Local6,
+    Local7
 }
 
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
@@ -383,7 +515,7 @@ pub struct SyslogLoggingConfig {
     pub host: String,
     pub port: u16,
     pub tls: TlsConfig,
-    pub facility: SyslogFacility,
+    pub facility: SyslogFacility
 }
 
 #[derive(Default, PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
@@ -397,96 +529,82 @@ pub struct SyslogLoggingConfigRequest {
     #[serde(default)]
     pub tls: Option<TlsConfig>,
     #[serde(default)]
-    pub facility: Option<SyslogFacility>,
+    pub facility: Option<SyslogFacility>
 }
 
+/// These settings will allow the service to validate the Google-issued
+/// authorization tokens used in Workspace CSE APIs.
+///
+/// For example, the specific settings for CSE Docs & Drive are:
+/// - JWKS URL: https://www.googleapis.com/service_accounts/v1/jwk/gsuitecse-tokenissuer-drive@system.gserviceaccount.com
+/// - Issuer: gsuitecse-tokenissuer-drive@system.gserviceaccount.com
+/// - Audience: cse-authorization
+///
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "snake_case")]
-pub enum LoggingConfig {
-    Splunk(SplunkLoggingConfig),
-    Stackdriver(StackdriverLoggingConfig),
-    Syslog(SyslogLoggingConfig),
+pub struct WorkspaceCseAuthorizationProvider {
+    /// Authorization provider's name
+    pub name: String,
+    /// A URL pointing to the JWKS endpoint
+    pub jwks_url: String,
+    /// Number of seconds that the service is allowed to cache the fetched keys
+    pub cache_duration: u64,
+    /// Acceptable values for the `iss` (issuer) field used in Google's
+    /// authorization tokens
+    pub valid_issuers: HashSet<String>,
+    /// Acceptable values for the `aud` (audience) field used in Google's
+    /// authorization tokens
+    pub valid_audiences: HashSet<String>
 }
 
+/// Workspace CSE API settings. Specifying these settings enables the CSE APIs
+/// for the account.
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "snake_case")]
-pub enum LoggingConfigRequest {
-    Splunk(SplunkLoggingConfigRequest),
-    Stackdriver(StackdriverLoggingConfigRequest),
-    Syslog(SyslogLoggingConfigRequest),
+pub struct WorkspaceCseConfig {
+    /// One or more Identity Providers (IdP) trusted to authenticate users.
+    /// Note that we don't check if Single Sign-On (SSO) settings exist for
+    /// each IdP listed here, but it is recommended to add these IdPs in SSO
+    /// settings as well (usually as OAuth/OIDC providers).
+    pub identity_providers: Vec<WorkspaceCseIdentityProvider>,
+    /// One or more authorization providers used to validate authorization
+    /// tokens. Different Workspace applications might require different
+    /// authorization settings.
+    pub authorization_providers: Vec<WorkspaceCseAuthorizationProvider>
 }
 
-#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
-pub struct GetUsageResponse {
-    pub num_operations: u64,
-}
-
-/// Account authentication settings.
+/// An identity provider trusted to authenticate users for Workspace CSE APIs
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
-pub struct AuthConfig {
-    #[serde(default)]
-    pub password: Option<AuthConfigPassword>,
-    #[serde(default)]
-    pub saml: Option<String>,
-    #[serde(default)]
-    pub oauth: Option<AuthConfigOauth>,
-    #[serde(default)]
-    pub ldap: HashMap<Uuid, AuthConfigLdap>,
-    #[serde(default)]
-    pub signed_jwt: Option<AuthConfigSignedJwt>,
+pub struct WorkspaceCseIdentityProvider {
+    /// Identity provider's name
+    pub name: String,
+    /// The public key(s) used to validate the authentication tokens
+    pub signing_keys: JwtSigningKeys,
+    /// Acceptable values for the `iss` (issuer) field used in authentication
+    /// tokens
+    pub valid_issuers: HashSet<String>,
+    /// Acceptable values for the `aud` (audience) field used in authentication
+    /// tokens
+    pub valid_audiences: HashSet<String>
 }
 
-pub struct OperationListAccounts;
+pub struct OperationAccountUsage;
 #[allow(unused)]
-impl Operation for OperationListAccounts {
-    type PathParams = ();
-    type QueryParams = GetAccountParams;
-    type Body = ();
-    type Output = Vec<Account>;
-
-    fn method() -> Method {
-        Method::GET
-    }
-    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
-        format!("/sys/v1/accounts?{q}", q = q.encode())
-    }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
-        None
-    }
-}
-
-impl SdkmsClient {
-    pub fn list_accounts(&self, query_params: Option<&GetAccountParams>) -> Result<Vec<Account>> {
-        self.execute::<OperationListAccounts>(&(), (), query_params)
-    }
-}
-
-pub struct OperationGetAccount;
-#[allow(unused)]
-impl Operation for OperationGetAccount {
+impl Operation for OperationAccountUsage {
     type PathParams = (Uuid,);
-    type QueryParams = GetAccountParams;
+    type QueryParams = CountParams;
     type Body = ();
-    type Output = Account;
+    type Output = GetUsageResponse;
 
     fn method() -> Method {
         Method::GET
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
-        format!("/sys/v1/accounts/{id}?{q}", id = p.0, q = q.encode())
+        format!("/sys/v1/accounts/{id}/usage?{q}", id = p.0, q = q.encode())
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
-        None
-    }
-}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
 
 impl SdkmsClient {
-    pub fn get_account(
-        &self,
-        id: &Uuid,
-        query_params: Option<&GetAccountParams>,
-    ) -> Result<Account> {
-        self.execute::<OperationGetAccount>(&(), (id,), query_params)
+    pub fn account_usage(&self, id: &Uuid, query_params: Option<&CountParams>) -> Result<GetUsageResponse> {
+        self.execute::<OperationAccountUsage>(&(), (id,), query_params)
     }
 }
 
@@ -511,11 +629,75 @@ impl SdkmsClient {
         self.execute::<OperationCreateAccount>(req, (), None)
     }
     pub fn request_approval_to_create_account(
-        &self,
-        req: &AccountRequest,
-        description: Option<String>,
-    ) -> Result<PendingApproval<OperationCreateAccount>> {
+        &self, req: &AccountRequest,
+        description: Option<String>) -> Result<PendingApproval<OperationCreateAccount>> {
         self.request_approval::<OperationCreateAccount>(req, (), None, description)
+    }
+}
+
+pub struct OperationDeleteAccount;
+#[allow(unused)]
+impl Operation for OperationDeleteAccount {
+    type PathParams = (Uuid,);
+    type QueryParams = ();
+    type Body = ();
+    type Output = ();
+
+    fn method() -> Method {
+        Method::DELETE
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/sys/v1/accounts/{id}", id = p.0)
+    }
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+
+impl SdkmsClient {
+    pub fn delete_account(&self, id: &Uuid) -> Result<()> {
+        self.execute::<OperationDeleteAccount>(&(), (id,), None)
+    }
+}
+
+pub struct OperationGetAccount;
+#[allow(unused)]
+impl Operation for OperationGetAccount {
+    type PathParams = (Uuid,);
+    type QueryParams = GetAccountParams;
+    type Body = ();
+    type Output = Account;
+
+    fn method() -> Method {
+        Method::GET
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/sys/v1/accounts/{id}?{q}", id = p.0, q = q.encode())
+    }
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+
+impl SdkmsClient {
+    pub fn get_account(&self, id: &Uuid, query_params: Option<&GetAccountParams>) -> Result<Account> {
+        self.execute::<OperationGetAccount>(&(), (id,), query_params)
+    }
+}
+
+pub struct OperationListAccounts;
+#[allow(unused)]
+impl Operation for OperationListAccounts {
+    type PathParams = ();
+    type QueryParams = GetAccountParams;
+    type Body = ();
+    type Output = Vec<Account>;
+
+    fn method() -> Method {
+        Method::GET
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/sys/v1/accounts?{q}", q = q.encode())
+    }
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+
+impl SdkmsClient {
+    pub fn list_accounts(&self, query_params: Option<&GetAccountParams>) -> Result<Vec<Account>> {
+        self.execute::<OperationListAccounts>(&(), (), query_params)
     }
 }
 
@@ -540,65 +722,9 @@ impl SdkmsClient {
         self.execute::<OperationUpdateAccount>(req, (id,), None)
     }
     pub fn request_approval_to_update_account(
-        &self,
-        id: &Uuid,
-        req: &AccountRequest,
-        description: Option<String>,
-    ) -> Result<PendingApproval<OperationUpdateAccount>> {
+        &self, id: &Uuid, req: &AccountRequest,
+        description: Option<String>) -> Result<PendingApproval<OperationUpdateAccount>> {
         self.request_approval::<OperationUpdateAccount>(req, (id,), None, description)
     }
 }
 
-pub struct OperationDeleteAccount;
-#[allow(unused)]
-impl Operation for OperationDeleteAccount {
-    type PathParams = (Uuid,);
-    type QueryParams = ();
-    type Body = ();
-    type Output = ();
-
-    fn method() -> Method {
-        Method::DELETE
-    }
-    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
-        format!("/sys/v1/accounts/{id}", id = p.0)
-    }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
-        None
-    }
-}
-
-impl SdkmsClient {
-    pub fn delete_account(&self, id: &Uuid) -> Result<()> {
-        self.execute::<OperationDeleteAccount>(&(), (id,), None)
-    }
-}
-
-pub struct OperationAccountUsage;
-#[allow(unused)]
-impl Operation for OperationAccountUsage {
-    type PathParams = (Uuid,);
-    type QueryParams = CountParams;
-    type Body = ();
-    type Output = GetUsageResponse;
-
-    fn method() -> Method {
-        Method::GET
-    }
-    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
-        format!("/sys/v1/accounts/{id}/usage?{q}", id = p.0, q = q.encode())
-    }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
-        None
-    }
-}
-
-impl SdkmsClient {
-    pub fn account_usage(
-        &self,
-        id: &Uuid,
-        query_params: Option<&CountParams>,
-    ) -> Result<GetUsageResponse> {
-        self.execute::<OperationAccountUsage>(&(), (id,), query_params)
-    }
-}

--- a/src/generated/approval_requests_generated.rs
+++ b/src/generated/approval_requests_generated.rs
@@ -5,48 +5,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::*;
-use serde::{Deserialize, Serialize};
-
-/// A Principal who can approve or deny an approval request.
-#[derive(Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "lowercase")]
-pub enum ReviewerPrincipal {
-    App(Uuid),
-    User(Uuid),
-}
-
-/// Approval request status.
-#[derive(Debug, Eq, PartialEq, Copy, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "UPPERCASE")]
-pub enum ApprovalStatus {
-    Pending,
-    Approved,
-    Denied,
-    Failed,
-}
-
-/// Identifies an object acted upon by an approval request.
-#[derive(Copy, Eq, PartialEq, Hash, Debug, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "lowercase")]
-pub enum ApprovalSubject {
-    Group(Uuid),
-    Sobject(Uuid),
-    App(Uuid),
-    Plugin(Uuid),
-    Account(Uuid),
-    NewAccount,
-}
-
-/// Reviewer of an approval request.
-#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
-pub struct Reviewer {
-    #[serde(flatten)]
-    pub entity: ReviewerPrincipal,
-    #[serde(default)]
-    pub requires_password: bool,
-    #[serde(default)]
-    pub requires_2fa: bool,
-}
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ApprovalRequest {
@@ -55,6 +13,8 @@ pub struct ApprovalRequest {
     #[serde(default)]
     pub body: Option<serde_json::Value>,
     pub created_at: Time,
+    #[serde(default)]
+    pub denial_reason: Option<String>,
     #[serde(default)]
     pub denier: Option<ReviewerPrincipal>,
     #[serde(default)]
@@ -68,7 +28,7 @@ pub struct ApprovalRequest {
     pub reviewers: Option<Vec<Reviewer>>,
     pub status: ApprovalStatus,
     #[serde(default)]
-    pub subjects: Option<HashSet<ApprovalSubject>>,
+    pub subjects: Option<HashSet<ApprovalSubject>>
 }
 
 #[derive(Default, Debug, Serialize, Deserialize, Clone)]
@@ -80,7 +40,55 @@ pub struct ApprovalRequestRequest {
     #[serde(default)]
     pub method: Option<String>,
     #[serde(default)]
-    pub operation: Option<String>,
+    pub operation: Option<String>
+}
+
+/// Approval request status.
+#[derive(Debug, Eq, PartialEq, Copy, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum ApprovalStatus {
+    Pending,
+    Approved,
+    Denied,
+    Failed
+}
+
+/// Identifies an object acted upon by an approval request.
+#[derive(Copy, Eq, PartialEq, Hash, Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "lowercase")]
+pub enum ApprovalSubject {
+    Group (
+        Uuid
+    ),
+    Sobject (
+        Uuid
+    ),
+    App (
+        Uuid
+    ),
+    Plugin (
+        Uuid
+    ),
+    Account (
+        Uuid
+    ),
+    NewAccount
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+pub struct ApproveRequest {
+    /// Password is required if the approval policy requires password authentication.
+    pub password: Option<String>,
+    /// U2F is required if the approval policy requires two factor authentication.
+    pub u2f: Option<U2fAuthRequest>,
+    /// Data associated with the approval
+    #[serde(default)]
+    pub body: Option<serde_json::Value>
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+pub struct DenyRequest {
+    pub reason: Option<String>
 }
 
 #[derive(Serialize, Deserialize, Clone, Default)]
@@ -88,84 +96,68 @@ pub struct ListApprovalRequestsParams {
     pub requester: Option<Uuid>,
     pub reviewer: Option<Uuid>,
     pub subject: Option<Uuid>,
-    pub status: Option<ApprovalStatus>,
+    pub status: Option<ApprovalStatus>
 }
 
 impl UrlEncode for ListApprovalRequestsParams {
-    fn url_encode(&self, m: &mut HashMap<&'static str, String>) {
+    fn url_encode(&self, m: &mut HashMap<String, String>) {
         if let Some(ref v) = self.requester {
-            m.insert("requester", v.to_string());
+            m.insert("requester".to_string(), v.to_string());
         }
         if let Some(ref v) = self.reviewer {
-            m.insert("reviewer", v.to_string());
+            m.insert("reviewer".to_string(), v.to_string());
         }
         if let Some(ref v) = self.subject {
-            m.insert("subject", v.to_string());
+            m.insert("subject".to_string(), v.to_string());
         }
         if let Some(ref v) = self.status {
-            m.insert("status", v.to_string());
+            m.insert("status".to_string(), v.to_string());
         }
     }
 }
 
-#[derive(Debug, Eq, PartialEq, Default, Serialize, Deserialize, Clone)]
-pub struct ApproveRequest {
-    /// Password is required if the approval policy requires password authentication.
-    pub password: Option<String>,
-    /// U2F is required if the approval policy requires two factor authentication.
-    pub u2f: Option<U2fAuthRequest>,
+/// Reviewer of an approval request.
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
+pub struct Reviewer {
+    #[serde(flatten)]
+    pub entity: ReviewerPrincipal,
+    #[serde(default)]
+    pub requires_password: bool,
+    #[serde(default)]
+    pub requires_2fa: bool
 }
 
-pub struct OperationListApprovalRequests;
+/// A Principal who can approve or deny an approval request.
+#[derive(Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "lowercase")]
+pub enum ReviewerPrincipal {
+    App (
+        Uuid
+    ),
+    User (
+        Uuid
+    )
+}
+
+pub struct OperationApproveRequest;
 #[allow(unused)]
-impl Operation for OperationListApprovalRequests {
-    type PathParams = ();
-    type QueryParams = ListApprovalRequestsParams;
-    type Body = ();
-    type Output = Vec<ApprovalRequest>;
-
-    fn method() -> Method {
-        Method::GET
-    }
-    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
-        format!("/sys/v1/approval_requests?{q}", q = q.encode())
-    }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
-        None
-    }
-}
-
-impl SdkmsClient {
-    pub fn list_approval_requests(
-        &self,
-        query_params: Option<&ListApprovalRequestsParams>,
-    ) -> Result<Vec<ApprovalRequest>> {
-        self.execute::<OperationListApprovalRequests>(&(), (), query_params)
-    }
-}
-
-pub struct OperationGetApprovalRequest;
-#[allow(unused)]
-impl Operation for OperationGetApprovalRequest {
+impl Operation for OperationApproveRequest {
     type PathParams = (Uuid,);
     type QueryParams = ();
-    type Body = ();
+    type Body = ApproveRequest;
     type Output = ApprovalRequest;
 
     fn method() -> Method {
-        Method::GET
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
-        format!("/sys/v1/approval_requests/{id}", id = p.0)
-    }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
-        None
+        format!("/sys/v1/approval_requests/{id}/approve", id = p.0)
     }
 }
 
 impl SdkmsClient {
-    pub fn get_approval_request(&self, id: &Uuid) -> Result<ApprovalRequest> {
-        self.execute::<OperationGetApprovalRequest>(&(), (id,), None)
+    pub fn approve_request(&self, id: &Uuid, req: &ApproveRequest) -> Result<ApprovalRequest> {
+        self.execute::<OperationApproveRequest>(req, (id,), None)
     }
 }
 
@@ -191,25 +183,25 @@ impl SdkmsClient {
     }
 }
 
-pub struct OperationApproveRequest;
+pub struct OperationDeleteApprovalRequest;
 #[allow(unused)]
-impl Operation for OperationApproveRequest {
+impl Operation for OperationDeleteApprovalRequest {
     type PathParams = (Uuid,);
     type QueryParams = ();
-    type Body = ApproveRequest;
-    type Output = ApprovalRequest;
+    type Body = ();
+    type Output = ();
 
     fn method() -> Method {
-        Method::POST
+        Method::DELETE
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
-        format!("/sys/v1/approval_requests/{id}/approve", id = p.0)
+        format!("/sys/v1/approval_requests/{id}", id = p.0)
     }
-}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
 
 impl SdkmsClient {
-    pub fn approve_request(&self, id: &Uuid, req: &ApproveRequest) -> Result<ApprovalRequest> {
-        self.execute::<OperationApproveRequest>(req, (id,), None)
+    pub fn delete_approval_request(&self, id: &Uuid) -> Result<()> {
+        self.execute::<OperationDeleteApprovalRequest>(&(), (id,), None)
     }
 }
 
@@ -218,7 +210,7 @@ pub struct OperationDenyRequest;
 impl Operation for OperationDenyRequest {
     type PathParams = (Uuid,);
     type QueryParams = ();
-    type Body = ();
+    type Body = DenyRequest;
     type Output = ApprovalRequest;
 
     fn method() -> Method {
@@ -227,14 +219,33 @@ impl Operation for OperationDenyRequest {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/approval_requests/{id}/deny", id = p.0)
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
-        None
-    }
 }
 
 impl SdkmsClient {
-    pub fn deny_request(&self, id: &Uuid) -> Result<ApprovalRequest> {
-        self.execute::<OperationDenyRequest>(&(), (id,), None)
+    pub fn deny_request(&self, id: &Uuid, req: &DenyRequest) -> Result<ApprovalRequest> {
+        self.execute::<OperationDenyRequest>(req, (id,), None)
+    }
+}
+
+pub struct OperationGetApprovalRequest;
+#[allow(unused)]
+impl Operation for OperationGetApprovalRequest {
+    type PathParams = (Uuid,);
+    type QueryParams = ();
+    type Body = ();
+    type Output = ApprovalRequest;
+
+    fn method() -> Method {
+        Method::GET
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/sys/v1/approval_requests/{id}", id = p.0)
+    }
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+
+impl SdkmsClient {
+    pub fn get_approval_request(&self, id: &Uuid) -> Result<ApprovalRequest> {
+        self.execute::<OperationGetApprovalRequest>(&(), (id,), None)
     }
 }
 
@@ -252,10 +263,7 @@ impl Operation for OperationGetApprovalRequestResult {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/approval_requests/{id}/result", id = p.0)
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
-        None
-    }
-}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
 
 impl SdkmsClient {
     pub fn get_approval_request_result(&self, id: &Uuid) -> Result<ApprovableResult> {
@@ -263,27 +271,47 @@ impl SdkmsClient {
     }
 }
 
-pub struct OperationDeleteApprovalRequest;
+pub struct OperationListApprovalRequests;
 #[allow(unused)]
-impl Operation for OperationDeleteApprovalRequest {
+impl Operation for OperationListApprovalRequests {
+    type PathParams = ();
+    type QueryParams = ListApprovalRequestsParams;
+    type Body = ();
+    type Output = Vec<ApprovalRequest>;
+
+    fn method() -> Method {
+        Method::GET
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/sys/v1/approval_requests?{q}", q = q.encode())
+    }
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+
+impl SdkmsClient {
+    pub fn list_approval_requests(&self, query_params: Option<&ListApprovalRequestsParams>) -> Result<Vec<ApprovalRequest>> {
+        self.execute::<OperationListApprovalRequests>(&(), (), query_params)
+    }
+}
+
+pub struct OperationMfaChallenge;
+#[allow(unused)]
+impl Operation for OperationMfaChallenge {
     type PathParams = (Uuid,);
     type QueryParams = ();
     type Body = ();
-    type Output = ();
+    type Output = MfaChallengeResponse;
 
     fn method() -> Method {
-        Method::DELETE
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
-        format!("/sys/v1/approval_requests/{id}", id = p.0)
+        format!("/sys/v1/approval_requests/{id}/challenge", id = p.0)
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
-        None
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+
+impl SdkmsClient {
+    pub fn mfa_challenge(&self, id: &Uuid) -> Result<MfaChallengeResponse> {
+        self.execute::<OperationMfaChallenge>(&(), (id,), None)
     }
 }
 
-impl SdkmsClient {
-    pub fn delete_approval_request(&self, id: &Uuid) -> Result<()> {
-        self.execute::<OperationDeleteApprovalRequest>(&(), (id,), None)
-    }
-}

--- a/src/generated/approval_requests_generated.rs
+++ b/src/generated/approval_requests_generated.rs
@@ -28,7 +28,7 @@ pub struct ApprovalRequest {
     pub reviewers: Option<Vec<Reviewer>>,
     pub status: ApprovalStatus,
     #[serde(default)]
-    pub subjects: Option<HashSet<ApprovalSubject>>
+    pub subjects: Option<HashSet<ApprovalSubject>>,
 }
 
 #[derive(Default, Debug, Serialize, Deserialize, Clone)]
@@ -40,7 +40,7 @@ pub struct ApprovalRequestRequest {
     #[serde(default)]
     pub method: Option<String>,
     #[serde(default)]
-    pub operation: Option<String>
+    pub operation: Option<String>,
 }
 
 /// Approval request status.
@@ -50,29 +50,19 @@ pub enum ApprovalStatus {
     Pending,
     Approved,
     Denied,
-    Failed
+    Failed,
 }
 
 /// Identifies an object acted upon by an approval request.
 #[derive(Copy, Eq, PartialEq, Hash, Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum ApprovalSubject {
-    Group (
-        Uuid
-    ),
-    Sobject (
-        Uuid
-    ),
-    App (
-        Uuid
-    ),
-    Plugin (
-        Uuid
-    ),
-    Account (
-        Uuid
-    ),
-    NewAccount
+    Group(Uuid),
+    Sobject(Uuid),
+    App(Uuid),
+    Plugin(Uuid),
+    Account(Uuid),
+    NewAccount,
 }
 
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
@@ -83,12 +73,12 @@ pub struct ApproveRequest {
     pub u2f: Option<U2fAuthRequest>,
     /// Data associated with the approval
     #[serde(default)]
-    pub body: Option<serde_json::Value>
+    pub body: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
 pub struct DenyRequest {
-    pub reason: Option<String>
+    pub reason: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Default)]
@@ -96,7 +86,7 @@ pub struct ListApprovalRequestsParams {
     pub requester: Option<Uuid>,
     pub reviewer: Option<Uuid>,
     pub subject: Option<Uuid>,
-    pub status: Option<ApprovalStatus>
+    pub status: Option<ApprovalStatus>,
 }
 
 impl UrlEncode for ListApprovalRequestsParams {
@@ -124,19 +114,15 @@ pub struct Reviewer {
     #[serde(default)]
     pub requires_password: bool,
     #[serde(default)]
-    pub requires_2fa: bool
+    pub requires_2fa: bool,
 }
 
 /// A Principal who can approve or deny an approval request.
 #[derive(Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum ReviewerPrincipal {
-    App (
-        Uuid
-    ),
-    User (
-        Uuid
-    )
+    App(Uuid),
+    User(Uuid),
 }
 
 pub struct OperationApproveRequest;
@@ -197,7 +183,10 @@ impl Operation for OperationDeleteApprovalRequest {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/approval_requests/{id}", id = p.0)
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
+        None
+    }
+}
 
 impl SdkmsClient {
     pub fn delete_approval_request(&self, id: &Uuid) -> Result<()> {
@@ -241,7 +230,10 @@ impl Operation for OperationGetApprovalRequest {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/approval_requests/{id}", id = p.0)
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
+        None
+    }
+}
 
 impl SdkmsClient {
     pub fn get_approval_request(&self, id: &Uuid) -> Result<ApprovalRequest> {
@@ -263,7 +255,10 @@ impl Operation for OperationGetApprovalRequestResult {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/approval_requests/{id}/result", id = p.0)
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
+        None
+    }
+}
 
 impl SdkmsClient {
     pub fn get_approval_request_result(&self, id: &Uuid) -> Result<ApprovableResult> {
@@ -285,10 +280,16 @@ impl Operation for OperationListApprovalRequests {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/approval_requests?{q}", q = q.encode())
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
+        None
+    }
+}
 
 impl SdkmsClient {
-    pub fn list_approval_requests(&self, query_params: Option<&ListApprovalRequestsParams>) -> Result<Vec<ApprovalRequest>> {
+    pub fn list_approval_requests(
+        &self,
+        query_params: Option<&ListApprovalRequestsParams>,
+    ) -> Result<Vec<ApprovalRequest>> {
         self.execute::<OperationListApprovalRequests>(&(), (), query_params)
     }
 }
@@ -307,11 +308,13 @@ impl Operation for OperationMfaChallenge {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/approval_requests/{id}/challenge", id = p.0)
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
+        None
+    }
+}
 
 impl SdkmsClient {
     pub fn mfa_challenge(&self, id: &Uuid) -> Result<MfaChallengeResponse> {
         self.execute::<OperationMfaChallenge>(&(), (id,), None)
     }
 }
-

--- a/src/generated/apps_generated.rs
+++ b/src/generated/apps_generated.rs
@@ -5,68 +5,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::*;
-use serde::{Deserialize, Serialize};
-
-/// Operations allowed to be performed by an app.
-pub use self::app_permissions::AppPermissions;
-pub mod app_permissions {
-    bitflags_set! {
-        pub struct AppPermissions: u64 {
-            const SIGN = 0x0000000000000001;
-            const VERIFY = 0x0000000000000002;
-            const ENCRYPT = 0x0000000000000004;
-            const DECRYPT = 0x0000000000000008;
-            const WRAPKEY = 0x0000000000000010;
-            const UNWRAPKEY = 0x0000000000000020;
-            const DERIVEKEY = 0x0000000000000040;
-            const MACGENERATE = 0x0000000000000080;
-            const MACVERIFY = 0x0000000000000100;
-            const EXPORT = 0x0000000000000200;
-            const MANAGE = 0x0000000000000400;
-            const AGREEKEY = 0x0000000000000800;
-            const MASKDECRYPT = 0x0000000000001000;
-        }
-    }
-}
-
-/// OAuth settings for an app. If enabled, an app can request to act on behalf of a user.
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "snake_case", tag = "state")]
-pub enum AppOauthConfig {
-    Enabled { redirect_uris: Vec<String> },
-    Disabled,
-}
-
-/// A trusted CA for app authentication.
-#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
-pub struct TrustAnchor {
-    pub subject: Vec<[String; 2]>,
-    pub ca_certificate: Blob,
-}
-
-/// App authentication mechanisms.
-#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "lowercase")]
-pub enum AppCredential {
-    Secret(String),
-    Certificate(Blob),
-    TrustedCa(TrustAnchor),
-    GoogleServiceAccount {},
-    SignedJwt {
-        valid_issuers: HashSet<String>,
-        signing_keys: JwtSigningKeys,
-    },
-}
-
-/// Authentication method of an app.
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub enum AppAuthType {
-    Secret,
-    Certificate,
-    TrustedCa,
-    GoogleServiceAccount,
-    SignedJwt,
-}
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct App {
@@ -77,6 +15,7 @@ pub struct App {
     pub auth_type: Option<AppAuthType>,
     #[serde(default)]
     pub cert_not_after: Option<Time>,
+    pub client_configurations: ClientConfigurations,
     pub created_at: Time,
     pub creator: Principal,
     #[serde(default)]
@@ -87,11 +26,75 @@ pub struct App {
     pub groups: AppGroups,
     #[serde(default)]
     pub interface: Option<String>,
+    pub ip_address_policy: IpAddressPolicy,
+    pub last_operations: LastAppOperationTimestamp,
     #[serde(default)]
     pub lastused_at: Option<Time>,
+    pub legacy_access: bool,
     pub name: String,
     #[serde(default)]
     pub oauth_config: Option<AppOauthConfig>,
+    pub role: AppRole
+}
+
+/// Authentication method of an app.
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
+pub enum AppAuthType {
+    Secret,
+    Certificate,
+    TrustedCa,
+    GoogleServiceAccount,
+    SignedJwt,
+    Ldap,
+    AwsIam
+}
+
+/// App authentication mechanisms.
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "lowercase")]
+pub enum AppCredential {
+    Secret (
+        String
+    ),
+    Certificate (
+        Blob
+    ),
+    TrustedCa (
+        TrustAnchor
+    ),
+    GoogleServiceAccount {
+        #[serde(default)]
+        access_reason_policy: Option<GoogleAccessReasonPolicy>
+    },
+    SignedJwt {
+        valid_issuers: HashSet<String>,
+        signing_keys: JwtSigningKeys
+    },
+    Ldap (
+        Uuid
+    ),
+    AwsIam {
+
+    }
+}
+
+/// App credential response.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct AppCredentialResponse {
+    pub app_id: Uuid,
+    pub credential: AppCredential,
+    #[serde(default)]
+    pub previous_credential: Option<PreviousCredential>
+}
+
+/// OAuth settings for an app. If enabled, an app can request to act on behalf of a user.
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "snake_case", tag = "state")]
+pub enum AppOauthConfig {
+    Enabled {
+        redirect_uris: Vec<String>
+    },
+    Disabled
 }
 
 #[derive(Default, Debug, Serialize, Deserialize, Clone)]
@@ -101,7 +104,11 @@ pub struct AppRequest {
     #[serde(default)]
     pub app_type: Option<String>,
     #[serde(default)]
+    pub client_configurations: Option<ClientConfigurationsRequest>,
+    #[serde(default)]
     pub credential: Option<AppCredential>,
+    #[serde(default)]
+    pub credential_migration_period: Option<u32>,
     #[serde(default)]
     pub default_group: Option<Uuid>,
     #[serde(default)]
@@ -113,13 +120,17 @@ pub struct AppRequest {
     #[serde(default)]
     pub interface: Option<String>,
     #[serde(default)]
+    pub ip_address_policy: Option<IpAddressPolicy>,
+    #[serde(default)]
     pub mod_groups: Option<AppGroups>,
     #[serde(default)]
     pub name: Option<String>,
     #[serde(default)]
     pub oauth_config: Option<AppOauthConfig>,
     #[serde(default)]
-    pub secret_size: Option<u32>,
+    pub role: Option<AppRole>,
+    #[serde(default)]
+    pub secret_size: Option<u32>
 }
 
 #[derive(Default, Debug, Serialize, Deserialize, Clone)]
@@ -127,27 +138,100 @@ pub struct AppResetSecretRequest {
     /// Size of app's secret in bytes.
     #[serde(default)]
     pub secret_size: Option<u32>,
+    #[serde(default)]
+    pub credential_migration_period: Option<u32>
 }
 
-/// App credential response.
+/// App's role.
+#[derive(Debug, Eq, PartialEq, Copy, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum AppRole {
+    Admin,
+    Crypto
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct AppCredentialResponse {
-    pub app_id: Uuid,
-    pub credential: AppCredential,
+pub enum AppSort {
+    ByAppId {
+        order: Order,
+        start: Option<Uuid>
+    }
+}
+
+impl UrlEncode for AppSort {
+    fn url_encode(&self, m: &mut HashMap<String, String>) {
+        match *self {
+            AppSort::ByAppId{ ref order, ref start } => {
+                m.insert("sort".to_string(), format!("app_id:{}", order));
+                if let Some(v) = start {
+                    m.insert("start".to_string(), v.to_string());
+                }
+            }
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Default)]
 pub struct GetAppParams {
     pub group_permissions: bool,
+    pub role: Option<String>
 }
 
 impl UrlEncode for GetAppParams {
-    fn url_encode(&self, m: &mut HashMap<&'static str, String>) {
-        m.insert("group_permissions", self.group_permissions.to_string());
+    fn url_encode(&self, m: &mut HashMap<String, String>) {
+        m.insert("group_permissions".to_string(), self.group_permissions.to_string());
+        if let Some(ref v) = self.role {
+            m.insert("role".to_string(), v.to_string());
+        }
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Default)]
+/// An access reason provided by Google when making EKMS API calls.
+#[derive(Debug, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum GoogleAccessReason {
+    ReasonUnspecified = 0,
+    CustomerInitiatedSupport = 1,
+    GoogleInitiatedService = 2,
+    ThirdPartyDataRequest = 3,
+    GoogleInitiatedReview = 4,
+    CustomerInitiatedAccess = 5,
+    GoogleInitiatedSystemOperation = 6,
+    ReasonNotExpected = 7,
+    ModifiedCustomerInitiatedAccess = 8
+}
+
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "snake_case")]
+pub struct GoogleAccessReasonPolicy {
+    pub allow: HashSet<GoogleAccessReason>,
+    pub allow_missing_reason: bool
+}
+
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum IpAddressPolicy {
+    AllowAll,
+    Whitelist (
+        HashSet<String>
+    )
+}
+
+#[derive(Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize, Clone)]
+pub struct LastAppOperationTimestamp {
+    #[serde(default)]
+    pub generic: Option<u64>,
+    #[serde(default)]
+    pub tokenization: Option<u64>,
+    #[serde(default)]
+    pub tep: Option<u64>,
+    #[serde(default)]
+    pub accelerator: Option<u64>,
+    #[serde(default)]
+    pub secrets_management: Option<u64>
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct ListAppsParams {
     pub group_id: Option<Uuid>,
     pub limit: Option<usize>,
@@ -155,93 +239,66 @@ pub struct ListAppsParams {
     #[serde(flatten)]
     pub sort: AppSort,
     pub group_permissions: bool,
+    pub role: Option<AppRole>
 }
 
 impl UrlEncode for ListAppsParams {
-    fn url_encode(&self, m: &mut HashMap<&'static str, String>) {
+    fn url_encode(&self, m: &mut HashMap<String, String>) {
         if let Some(ref v) = self.group_id {
-            m.insert("group_id", v.to_string());
+            m.insert("group_id".to_string(), v.to_string());
         }
         if let Some(ref v) = self.limit {
-            m.insert("limit", v.to_string());
+            m.insert("limit".to_string(), v.to_string());
         }
         if let Some(ref v) = self.offset {
-            m.insert("offset", v.to_string());
+            m.insert("offset".to_string(), v.to_string());
         }
         self.sort.url_encode(m);
-        m.insert("group_permissions", self.group_permissions.to_string());
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub enum AppSort {
-    ByAppId { order: Order, start: Option<Uuid> },
-}
-
-impl UrlEncode for AppSort {
-    fn url_encode(&self, m: &mut HashMap<&'static str, String>) {
-        match *self {
-            AppSort::ByAppId {
-                ref order,
-                ref start,
-            } => {
-                m.insert("sort", format!("app_id:{}", order));
-                if let Some(v) = start {
-                    m.insert("start", v.to_string());
-                }
-            }
+        m.insert("group_permissions".to_string(), self.group_permissions.to_string());
+        if let Some(ref v) = self.role {
+            m.insert("role".to_string(), v.to_string());
         }
     }
 }
 
-pub struct OperationListApps;
-#[allow(unused)]
-impl Operation for OperationListApps {
-    type PathParams = ();
-    type QueryParams = ListAppsParams;
-    type Body = ();
-    type Output = Vec<App>;
-
-    fn method() -> Method {
-        Method::GET
-    }
-    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
-        format!("/sys/v1/apps?{q}", q = q.encode())
-    }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
-        None
-    }
+/// Expired credentials that are still valid for a transitional period
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+pub struct PreviousCredential {
+    pub credential: AppCredential,
+    pub valid_until: Time
 }
 
-impl SdkmsClient {
-    pub fn list_apps(&self, query_params: Option<&ListAppsParams>) -> Result<Vec<App>> {
-        self.execute::<OperationListApps>(&(), (), query_params)
-    }
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum SubjectGeneral {
+    DirectoryName (
+        Vec<[String; 2]>
+    ),
+    DnsName (
+        String
+    ),
+    IpAddress (
+        IpAddr
+    )
 }
 
-pub struct OperationGetApp;
-#[allow(unused)]
-impl Operation for OperationGetApp {
-    type PathParams = (Uuid,);
-    type QueryParams = GetAppParams;
-    type Body = ();
-    type Output = App;
-
-    fn method() -> Method {
-        Method::GET
-    }
-    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
-        format!("/sys/v1/apps/{id}?{q}", id = p.0, q = q.encode())
-    }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
-        None
-    }
+/// A trusted CA for app authentication.
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+pub struct TrustAnchor {
+    #[serde(flatten)]
+    pub subject: TrustAnchorSubject,
+    pub ca_certificate: Blob
 }
 
-impl SdkmsClient {
-    pub fn get_app(&self, id: &Uuid, query_params: Option<&GetAppParams>) -> Result<App> {
-        self.execute::<OperationGetApp>(&(), (id,), query_params)
-    }
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum TrustAnchorSubject {
+    Subject (
+        Vec<[String; 2]>
+    ),
+    SubjectGeneral (
+        SubjectGeneral
+    )
 }
 
 pub struct OperationCreateApp;
@@ -266,33 +323,6 @@ impl SdkmsClient {
     }
 }
 
-pub struct OperationUpdateApp;
-#[allow(unused)]
-impl Operation for OperationUpdateApp {
-    type PathParams = (Uuid,);
-    type QueryParams = GetAppParams;
-    type Body = AppRequest;
-    type Output = App;
-
-    fn method() -> Method {
-        Method::PATCH
-    }
-    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
-        format!("/sys/v1/apps/{id}?{q}", id = p.0, q = q.encode())
-    }
-}
-
-impl SdkmsClient {
-    pub fn update_app(
-        &self,
-        id: &Uuid,
-        query_params: Option<&GetAppParams>,
-        req: &AppRequest,
-    ) -> Result<App> {
-        self.execute::<OperationUpdateApp>(req, (id,), query_params)
-    }
-}
-
 pub struct OperationDeleteApp;
 #[allow(unused)]
 impl Operation for OperationDeleteApp {
@@ -307,10 +337,7 @@ impl Operation for OperationDeleteApp {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/apps/{id}", id = p.0)
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
-        None
-    }
-}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
 
 impl SdkmsClient {
     pub fn delete_app(&self, id: &Uuid) -> Result<()> {
@@ -318,34 +345,25 @@ impl SdkmsClient {
     }
 }
 
-pub struct OperationResetAppSecret;
+pub struct OperationGetApp;
 #[allow(unused)]
-impl Operation for OperationResetAppSecret {
+impl Operation for OperationGetApp {
     type PathParams = (Uuid,);
     type QueryParams = GetAppParams;
-    type Body = AppResetSecretRequest;
+    type Body = ();
     type Output = App;
 
     fn method() -> Method {
-        Method::POST
+        Method::GET
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
-        format!(
-            "/sys/v1/apps/{id}/reset_secret?{q}",
-            id = p.0,
-            q = q.encode()
-        )
+        format!("/sys/v1/apps/{id}?{q}", id = p.0, q = q.encode())
     }
-}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
 
 impl SdkmsClient {
-    pub fn reset_app_secret(
-        &self,
-        id: &Uuid,
-        query_params: Option<&GetAppParams>,
-        req: &AppResetSecretRequest,
-    ) -> Result<App> {
-        self.execute::<OperationResetAppSecret>(req, (id,), query_params)
+    pub fn get_app(&self, id: &Uuid, query_params: Option<&GetAppParams>) -> Result<App> {
+        self.execute::<OperationGetApp>(&(), (id,), query_params)
     }
 }
 
@@ -363,20 +381,114 @@ impl Operation for OperationGetAppCredential {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/apps/{id}/credential", id = p.0)
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
-        None
-    }
-}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
 
 impl SdkmsClient {
     pub fn get_app_credential(&self, id: &Uuid) -> Result<AppCredentialResponse> {
         self.execute::<OperationGetAppCredential>(&(), (id,), None)
     }
     pub fn request_approval_to_get_app_credential(
-        &self,
-        id: &Uuid,
-        description: Option<String>,
-    ) -> Result<PendingApproval<OperationGetAppCredential>> {
+        &self, id: &Uuid,
+        description: Option<String>) -> Result<PendingApproval<OperationGetAppCredential>> {
         self.request_approval::<OperationGetAppCredential>(&(), (id,), None, description)
     }
 }
+
+pub struct OperationGetClientConfigs;
+#[allow(unused)]
+impl Operation for OperationGetClientConfigs {
+    type PathParams = ();
+    type QueryParams = ();
+    type Body = ();
+    type Output = ClientConfigurations;
+
+    fn method() -> Method {
+        Method::GET
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/sys/v1/apps/client_configs")
+    }
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+
+impl SdkmsClient {
+    pub fn get_client_configs(&self) -> Result<ClientConfigurations> {
+        self.execute::<OperationGetClientConfigs>(&(), (), None)
+    }
+}
+
+pub struct OperationListApps;
+#[allow(unused)]
+impl Operation for OperationListApps {
+    type PathParams = ();
+    type QueryParams = ListAppsParams;
+    type Body = ();
+    type Output = Vec<App>;
+
+    fn method() -> Method {
+        Method::GET
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/sys/v1/apps?{q}", q = q.encode())
+    }
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+
+impl SdkmsClient {
+    pub fn list_apps(&self, query_params: Option<&ListAppsParams>) -> Result<Vec<App>> {
+        self.execute::<OperationListApps>(&(), (), query_params)
+    }
+}
+
+pub struct OperationResetAppSecret;
+#[allow(unused)]
+impl Operation for OperationResetAppSecret {
+    type PathParams = (Uuid,);
+    type QueryParams = GetAppParams;
+    type Body = AppResetSecretRequest;
+    type Output = App;
+
+    fn method() -> Method {
+        Method::POST
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/sys/v1/apps/{id}/reset_secret?{q}", id = p.0, q = q.encode())
+    }
+}
+
+impl SdkmsClient {
+    pub fn reset_app_secret(&self, id: &Uuid, query_params: Option<&GetAppParams>, req: &AppResetSecretRequest) -> Result<App> {
+        self.execute::<OperationResetAppSecret>(req, (id,), query_params)
+    }
+    pub fn request_approval_to_reset_app_secret(
+        &self, id: &Uuid, query_params: Option<&GetAppParams>, req: &AppResetSecretRequest,
+        description: Option<String>) -> Result<PendingApproval<OperationResetAppSecret>> {
+        self.request_approval::<OperationResetAppSecret>(req, (id,), query_params, description)
+    }
+}
+
+pub struct OperationUpdateApp;
+#[allow(unused)]
+impl Operation for OperationUpdateApp {
+    type PathParams = (Uuid,);
+    type QueryParams = GetAppParams;
+    type Body = AppRequest;
+    type Output = App;
+
+    fn method() -> Method {
+        Method::PATCH
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/sys/v1/apps/{id}?{q}", id = p.0, q = q.encode())
+    }
+}
+
+impl SdkmsClient {
+    pub fn update_app(&self, id: &Uuid, query_params: Option<&GetAppParams>, req: &AppRequest) -> Result<App> {
+        self.execute::<OperationUpdateApp>(req, (id,), query_params)
+    }
+    pub fn request_approval_to_update_app(
+        &self, id: &Uuid, query_params: Option<&GetAppParams>, req: &AppRequest,
+        description: Option<String>) -> Result<PendingApproval<OperationUpdateApp>> {
+        self.request_approval::<OperationUpdateApp>(req, (id,), query_params, description)
+    }
+}
+

--- a/src/generated/apps_generated.rs
+++ b/src/generated/apps_generated.rs
@@ -34,7 +34,7 @@ pub struct App {
     pub name: String,
     #[serde(default)]
     pub oauth_config: Option<AppOauthConfig>,
-    pub role: AppRole
+    pub role: AppRole,
 }
 
 /// Authentication method of an app.
@@ -46,36 +46,26 @@ pub enum AppAuthType {
     GoogleServiceAccount,
     SignedJwt,
     Ldap,
-    AwsIam
+    AwsIam,
 }
 
 /// App authentication mechanisms.
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum AppCredential {
-    Secret (
-        String
-    ),
-    Certificate (
-        Blob
-    ),
-    TrustedCa (
-        TrustAnchor
-    ),
+    Secret(String),
+    Certificate(Blob),
+    TrustedCa(TrustAnchor),
     GoogleServiceAccount {
         #[serde(default)]
-        access_reason_policy: Option<GoogleAccessReasonPolicy>
+        access_reason_policy: Option<GoogleAccessReasonPolicy>,
     },
     SignedJwt {
         valid_issuers: HashSet<String>,
-        signing_keys: JwtSigningKeys
+        signing_keys: JwtSigningKeys,
     },
-    Ldap (
-        Uuid
-    ),
-    AwsIam {
-
-    }
+    Ldap(Uuid),
+    AwsIam {},
 }
 
 /// App credential response.
@@ -84,17 +74,15 @@ pub struct AppCredentialResponse {
     pub app_id: Uuid,
     pub credential: AppCredential,
     #[serde(default)]
-    pub previous_credential: Option<PreviousCredential>
+    pub previous_credential: Option<PreviousCredential>,
 }
 
 /// OAuth settings for an app. If enabled, an app can request to act on behalf of a user.
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "snake_case", tag = "state")]
 pub enum AppOauthConfig {
-    Enabled {
-        redirect_uris: Vec<String>
-    },
-    Disabled
+    Enabled { redirect_uris: Vec<String> },
+    Disabled,
 }
 
 #[derive(Default, Debug, Serialize, Deserialize, Clone)]
@@ -130,7 +118,7 @@ pub struct AppRequest {
     #[serde(default)]
     pub role: Option<AppRole>,
     #[serde(default)]
-    pub secret_size: Option<u32>
+    pub secret_size: Option<u32>,
 }
 
 #[derive(Default, Debug, Serialize, Deserialize, Clone)]
@@ -139,7 +127,7 @@ pub struct AppResetSecretRequest {
     #[serde(default)]
     pub secret_size: Option<u32>,
     #[serde(default)]
-    pub credential_migration_period: Option<u32>
+    pub credential_migration_period: Option<u32>,
 }
 
 /// App's role.
@@ -147,21 +135,21 @@ pub struct AppResetSecretRequest {
 #[serde(rename_all = "snake_case")]
 pub enum AppRole {
     Admin,
-    Crypto
+    Crypto,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum AppSort {
-    ByAppId {
-        order: Order,
-        start: Option<Uuid>
-    }
+    ByAppId { order: Order, start: Option<Uuid> },
 }
 
 impl UrlEncode for AppSort {
     fn url_encode(&self, m: &mut HashMap<String, String>) {
         match *self {
-            AppSort::ByAppId{ ref order, ref start } => {
+            AppSort::ByAppId {
+                ref order,
+                ref start,
+            } => {
                 m.insert("sort".to_string(), format!("app_id:{}", order));
                 if let Some(v) = start {
                     m.insert("start".to_string(), v.to_string());
@@ -174,12 +162,15 @@ impl UrlEncode for AppSort {
 #[derive(Serialize, Deserialize, Clone, Default)]
 pub struct GetAppParams {
     pub group_permissions: bool,
-    pub role: Option<String>
+    pub role: Option<String>,
 }
 
 impl UrlEncode for GetAppParams {
     fn url_encode(&self, m: &mut HashMap<String, String>) {
-        m.insert("group_permissions".to_string(), self.group_permissions.to_string());
+        m.insert(
+            "group_permissions".to_string(),
+            self.group_permissions.to_string(),
+        );
         if let Some(ref v) = self.role {
             m.insert("role".to_string(), v.to_string());
         }
@@ -190,9 +181,7 @@ impl UrlEncode for GetAppParams {
 #[serde(rename_all = "snake_case")]
 pub enum IpAddressPolicy {
     AllowAll,
-    Whitelist (
-        HashSet<String>
-    )
+    Whitelist(HashSet<String>),
 }
 
 #[derive(Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize, Clone)]
@@ -206,7 +195,7 @@ pub struct LastAppOperationTimestamp {
     #[serde(default)]
     pub accelerator: Option<u64>,
     #[serde(default)]
-    pub secrets_management: Option<u64>
+    pub secrets_management: Option<u64>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -217,7 +206,7 @@ pub struct ListAppsParams {
     #[serde(flatten)]
     pub sort: AppSort,
     pub group_permissions: bool,
-    pub role: Option<AppRole>
+    pub role: Option<AppRole>,
 }
 
 impl UrlEncode for ListAppsParams {
@@ -232,7 +221,10 @@ impl UrlEncode for ListAppsParams {
             m.insert("offset".to_string(), v.to_string());
         }
         self.sort.url_encode(m);
-        m.insert("group_permissions".to_string(), self.group_permissions.to_string());
+        m.insert(
+            "group_permissions".to_string(),
+            self.group_permissions.to_string(),
+        );
         if let Some(ref v) = self.role {
             m.insert("role".to_string(), v.to_string());
         }
@@ -243,21 +235,15 @@ impl UrlEncode for ListAppsParams {
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
 pub struct PreviousCredential {
     pub credential: AppCredential,
-    pub valid_until: Time
+    pub valid_until: Time,
 }
 
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum SubjectGeneral {
-    DirectoryName (
-        Vec<[String; 2]>
-    ),
-    DnsName (
-        String
-    ),
-    IpAddress (
-        IpAddr
-    )
+    DirectoryName(Vec<[String; 2]>),
+    DnsName(String),
+    IpAddress(IpAddr),
 }
 
 /// A trusted CA for app authentication.
@@ -265,18 +251,14 @@ pub enum SubjectGeneral {
 pub struct TrustAnchor {
     #[serde(flatten)]
     pub subject: TrustAnchorSubject,
-    pub ca_certificate: Blob
+    pub ca_certificate: Blob,
 }
 
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum TrustAnchorSubject {
-    Subject (
-        Vec<[String; 2]>
-    ),
-    SubjectGeneral (
-        SubjectGeneral
-    )
+    Subject(Vec<[String; 2]>),
+    SubjectGeneral(SubjectGeneral),
 }
 
 pub struct OperationCreateApp;
@@ -315,7 +297,10 @@ impl Operation for OperationDeleteApp {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/apps/{id}", id = p.0)
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
+        None
+    }
+}
 
 impl SdkmsClient {
     pub fn delete_app(&self, id: &Uuid) -> Result<()> {
@@ -337,7 +322,10 @@ impl Operation for OperationGetApp {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/apps/{id}?{q}", id = p.0, q = q.encode())
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
+        None
+    }
+}
 
 impl SdkmsClient {
     pub fn get_app(&self, id: &Uuid, query_params: Option<&GetAppParams>) -> Result<App> {
@@ -359,15 +347,20 @@ impl Operation for OperationGetAppCredential {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/apps/{id}/credential", id = p.0)
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
+        None
+    }
+}
 
 impl SdkmsClient {
     pub fn get_app_credential(&self, id: &Uuid) -> Result<AppCredentialResponse> {
         self.execute::<OperationGetAppCredential>(&(), (id,), None)
     }
     pub fn request_approval_to_get_app_credential(
-        &self, id: &Uuid,
-        description: Option<String>) -> Result<PendingApproval<OperationGetAppCredential>> {
+        &self,
+        id: &Uuid,
+        description: Option<String>,
+    ) -> Result<PendingApproval<OperationGetAppCredential>> {
         self.request_approval::<OperationGetAppCredential>(&(), (id,), None, description)
     }
 }
@@ -386,7 +379,10 @@ impl Operation for OperationGetClientConfigs {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/apps/client_configs")
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
+        None
+    }
+}
 
 impl SdkmsClient {
     pub fn get_client_configs(&self) -> Result<ClientConfigurations> {
@@ -408,7 +404,10 @@ impl Operation for OperationListApps {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/apps?{q}", q = q.encode())
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
+        None
+    }
+}
 
 impl SdkmsClient {
     pub fn list_apps(&self, query_params: Option<&ListAppsParams>) -> Result<Vec<App>> {
@@ -428,17 +427,30 @@ impl Operation for OperationResetAppSecret {
         Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
-        format!("/sys/v1/apps/{id}/reset_secret?{q}", id = p.0, q = q.encode())
+        format!(
+            "/sys/v1/apps/{id}/reset_secret?{q}",
+            id = p.0,
+            q = q.encode()
+        )
     }
 }
 
 impl SdkmsClient {
-    pub fn reset_app_secret(&self, id: &Uuid, query_params: Option<&GetAppParams>, req: &AppResetSecretRequest) -> Result<App> {
+    pub fn reset_app_secret(
+        &self,
+        id: &Uuid,
+        query_params: Option<&GetAppParams>,
+        req: &AppResetSecretRequest,
+    ) -> Result<App> {
         self.execute::<OperationResetAppSecret>(req, (id,), query_params)
     }
     pub fn request_approval_to_reset_app_secret(
-        &self, id: &Uuid, query_params: Option<&GetAppParams>, req: &AppResetSecretRequest,
-        description: Option<String>) -> Result<PendingApproval<OperationResetAppSecret>> {
+        &self,
+        id: &Uuid,
+        query_params: Option<&GetAppParams>,
+        req: &AppResetSecretRequest,
+        description: Option<String>,
+    ) -> Result<PendingApproval<OperationResetAppSecret>> {
         self.request_approval::<OperationResetAppSecret>(req, (id,), query_params, description)
     }
 }
@@ -460,13 +472,21 @@ impl Operation for OperationUpdateApp {
 }
 
 impl SdkmsClient {
-    pub fn update_app(&self, id: &Uuid, query_params: Option<&GetAppParams>, req: &AppRequest) -> Result<App> {
+    pub fn update_app(
+        &self,
+        id: &Uuid,
+        query_params: Option<&GetAppParams>,
+        req: &AppRequest,
+    ) -> Result<App> {
         self.execute::<OperationUpdateApp>(req, (id,), query_params)
     }
     pub fn request_approval_to_update_app(
-        &self, id: &Uuid, query_params: Option<&GetAppParams>, req: &AppRequest,
-        description: Option<String>) -> Result<PendingApproval<OperationUpdateApp>> {
+        &self,
+        id: &Uuid,
+        query_params: Option<&GetAppParams>,
+        req: &AppRequest,
+        description: Option<String>,
+    ) -> Result<PendingApproval<OperationUpdateApp>> {
         self.request_approval::<OperationUpdateApp>(req, (id,), query_params, description)
     }
 }
-

--- a/src/generated/apps_generated.rs
+++ b/src/generated/apps_generated.rs
@@ -186,28 +186,6 @@ impl UrlEncode for GetAppParams {
     }
 }
 
-/// An access reason provided by Google when making EKMS API calls.
-#[derive(Debug, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-pub enum GoogleAccessReason {
-    ReasonUnspecified = 0,
-    CustomerInitiatedSupport = 1,
-    GoogleInitiatedService = 2,
-    ThirdPartyDataRequest = 3,
-    GoogleInitiatedReview = 4,
-    CustomerInitiatedAccess = 5,
-    GoogleInitiatedSystemOperation = 6,
-    ReasonNotExpected = 7,
-    ModifiedCustomerInitiatedAccess = 8
-}
-
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "snake_case")]
-pub struct GoogleAccessReasonPolicy {
-    pub allow: HashSet<GoogleAccessReason>,
-    pub allow_missing_reason: bool
-}
-
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum IpAddressPolicy {

--- a/src/generated/common_generated.rs
+++ b/src/generated/common_generated.rs
@@ -14,7 +14,7 @@ pub enum AccountRole {
     MemberUser,
     AuditorUser,
     AdminApp,
-    CryptoApp
+    CryptoApp,
 }
 
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
@@ -24,7 +24,7 @@ pub struct AesOptions {
     pub tag_length: Option<i32>,
     pub cipher_mode: Option<CipherMode>,
     pub random_iv: Option<bool>,
-    pub iv_length: Option<i32>
+    pub iv_length: Option<i32>,
 }
 
 /// A cryptographic algorithm.
@@ -42,7 +42,7 @@ pub enum Algorithm {
     Hmac,
     LedaBeta,
     Round5Beta,
-    Pbe
+    Pbe,
 }
 
 /// A helper enum with a single variant, All, which indicates that something should apply to an
@@ -50,13 +50,13 @@ pub enum Algorithm {
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum All {
-    All
+    All,
 }
 
 /// Operations allowed to be performed by an app.
 pub use self::app_permissions::AppPermissions;
 pub mod app_permissions {
-    bitflags_set!{
+    bitflags_set! {
         pub struct AppPermissions: u64 {
             const SIGN = 0x0000000000000001;
             const VERIFY = 0x0000000000000002;
@@ -80,7 +80,7 @@ pub mod app_permissions {
 #[derive(Copy, PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
 pub struct ApprovalAuthConfig {
     pub require_password: bool,
-    pub require_2fa: bool
+    pub require_2fa: bool,
 }
 
 /// LDAP authentication settings.
@@ -98,32 +98,26 @@ pub struct AuthConfigLdap {
     #[serde(default)]
     pub service_account: Option<LdapServiceAccount>,
     #[serde(default)]
-    pub authorization: Option<LdapAuthorizationConfig>
+    pub authorization: Option<LdapAuthorizationConfig>,
 }
 
 /// CA settings.
 #[derive(PartialEq, Eq, Hash, Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum CaConfig {
-    CaSet (
-        CaSet
-    ),
-    Pinned (
-        Vec<Blob>
-    )
+    CaSet(CaSet),
+    Pinned(Vec<Blob>),
 }
 
 /// Predefined CA sets.
 #[derive(PartialEq, Eq, Hash, Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum CaSet {
-    GlobalRoots
+    GlobalRoots,
 }
 
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
-pub struct CertificateOptions {
-
-}
+pub struct CertificateOptions {}
 
 /// Cipher mode used for symmetric key algorithms.
 #[derive(Debug, Eq, PartialEq, Copy, Serialize, Deserialize, Clone)]
@@ -139,7 +133,7 @@ pub enum CipherMode {
     Ccm,
     Kw,
     Kwp,
-    Ff1
+    Ff1,
 }
 
 #[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize, Clone)]
@@ -150,23 +144,21 @@ pub struct ClientConfigurations {
     #[serde(default)]
     pub pkcs11: Option<Pkcs11ClientConfig>,
     #[serde(default)]
-    pub kmip: Option<KmipClientConfig>
+    pub kmip: Option<KmipClientConfig>,
 }
 
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
 pub struct ClientConfigurationsRequest {
     pub common: Option<Option<CommonClientConfig>>,
     pub pkcs11: Option<Option<Pkcs11ClientConfig>>,
-    pub kmip: Option<Option<KmipClientConfig>>
+    pub kmip: Option<Option<KmipClientConfig>>,
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "snake_case", tag = "mode")]
 pub enum ClientFileLogging {
-    Enabled (
-        ClientFileLoggingConfig
-    ),
-    Disabled
+    Enabled(ClientFileLoggingConfig),
+    Disabled,
 }
 
 #[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize, Clone)]
@@ -176,7 +168,7 @@ pub struct ClientFileLoggingConfig {
     #[serde(default)]
     pub file_size_kb: Option<u64>,
     #[serde(default)]
-    pub max_files: Option<u32>
+    pub max_files: Option<u32>,
 }
 
 #[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize, Clone)]
@@ -186,7 +178,7 @@ pub struct ClientLogConfig {
     #[serde(default)]
     pub file: Option<ClientFileLogging>,
     #[serde(default)]
-    pub level: Option<String>
+    pub level: Option<String>,
 }
 
 #[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize, Clone)]
@@ -196,22 +188,16 @@ pub struct CommonClientConfig {
     #[serde(default)]
     pub log: Option<ClientLogConfig>,
     #[serde(default)]
-    pub h2_num_connections: Option<usize>
+    pub h2_num_connections: Option<usize>,
 }
 
 /// `CipherMode` or `RsaEncryptionPadding`, depending on the encryption algorithm.
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
 #[serde(untagged)]
 pub enum CryptMode {
-    Symmetric (
-        CipherMode
-    ),
-    Rsa (
-        RsaEncryptionPadding
-    ),
-    Pkcs8Mode (
-        Pkcs8Mode
-    )
+    Symmetric(CipherMode),
+    Rsa(RsaEncryptionPadding),
+    Pkcs8Mode(Pkcs8Mode),
 }
 
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
@@ -228,7 +214,7 @@ pub struct CryptographicPolicy {
     pub secret: Option<SecretOptions>,
     pub certificate: Option<CertificateOptions>,
     pub key_ops: Option<KeyOperations>,
-    pub legacy_policy: Option<LegacyKeyPolicy>
+    pub legacy_policy: Option<LegacyKeyPolicy>,
 }
 
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
@@ -236,13 +222,13 @@ pub struct Des3Options {
     pub key_sizes: Option<Vec<u32>>,
     pub cipher_mode: Option<CipherMode>,
     pub random_iv: Option<bool>,
-    pub iv_length: Option<i32>
+    pub iv_length: Option<i32>,
 }
 
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
 pub struct DesOptions {
     pub cipher_mode: Option<CipherMode>,
-    pub random_iv: Option<bool>
+    pub random_iv: Option<bool>,
 }
 
 /// A hash algorithm.
@@ -265,17 +251,17 @@ pub enum DigestAlgorithm {
     Sha3_224,
     Sha3_256,
     Sha3_384,
-    Sha3_512
+    Sha3_512,
 }
 
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
 pub struct DsaOptions {
-    pub subgroup_size: Option<u32>
+    pub subgroup_size: Option<u32>,
 }
 
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
 pub struct EcOptions {
-    pub elliptic_curves: Option<Vec<EllipticCurve>>
+    pub elliptic_curves: Option<Vec<EllipticCurve>>,
 }
 
 /// Identifies a standardized elliptic curve.
@@ -292,34 +278,18 @@ pub enum EllipticCurve {
     NistP256,
     NistP384,
     NistP521,
-    Gost256A
+    Gost256A,
 }
 
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
 #[serde(untagged)]
 pub enum ExternalKeyId {
-    Pkcs11 {
-        id: Blob,
-        label: Blob
-    },
-    Fortanix {
-        id: Uuid
-    },
-    AwsKms {
-        key_arn: String,
-        key_id: String
-    },
-    AzureKeyVault {
-        version: Uuid,
-        label: String
-    },
-    GcpKeyRing {
-        version: u32,
-        label: String
-    },
-    Wrapped {
-
-    }
+    Pkcs11 { id: Blob, label: Blob },
+    Fortanix { id: Uuid },
+    AwsKms { key_arn: String, key_id: String },
+    AzureKeyVault { version: Uuid, label: String },
+    GcpKeyRing { version: u32, label: String },
+    Wrapped {},
 }
 
 /// This describes an external object. Virtual keys in SDKMS store this information instead of the key material.
@@ -328,7 +298,7 @@ pub struct ExternalSobjectInfo {
     /// The ID of the external object in the external HSM.
     pub id: ExternalKeyId,
     /// The group which corresponds to the external HSM.
-    pub hsm_group_id: Uuid
+    pub hsm_group_id: Uuid,
 }
 
 /// The character set to use for an encrypted portion of a complex tokenization data type.
@@ -372,7 +342,7 @@ pub enum FpeCompoundPart {
         min_length: Option<u32>,
         /// The maximum allowed length for this part (in chars).
         #[serde(default)]
-        max_length: Option<u32>
+        max_length: Option<u32>,
     },
     /// Represents a concatenation of multiple structures (in a particular order).
     Concat {
@@ -394,7 +364,7 @@ pub enum FpeCompoundPart {
         min_length: Option<u32>,
         /// The maximum allowed length for this part (in chars).
         #[serde(default)]
-        max_length: Option<u32>
+        max_length: Option<u32>,
     },
     /// Indicates a part that is possibly repeated multiple times.
     Multiple {
@@ -422,8 +392,8 @@ pub enum FpeCompoundPart {
         min_length: Option<u32>,
         /// The maximum allowed length for this part (in chars).
         #[serde(default)]
-        max_length: Option<u32>
-    }
+        max_length: Option<u32>,
+    },
 }
 
 /// Constraints on a portion of a complex tokenization data type.
@@ -456,7 +426,7 @@ pub struct FpeConstraints {
     pub date: Option<FpeDateConstraint>,
     /// The subparts to apply the constaints to. If not specified, the constraints will be
     /// applied to all subparts (recursively).
-    pub applies_to: FpeConstraintsApplicability
+    pub applies_to: FpeConstraintsApplicability,
 }
 
 /// A structure indicating which subparts to which to apply a set of constraints.
@@ -466,9 +436,7 @@ pub enum FpeConstraintsApplicability {
     /// Indicates that the constraints apply to the entire part (i.e., all of its subparts),
     /// including any descendants. This is the default value for this enum and the only option
     /// available for FpeEncryptedPart, literal, and OR subparts.
-    Simple (
-        All
-    ),
+    Simple(All),
     /// An object representing the individual subparts that the constraints should apply to. This
     /// is a BTreeMap where for each key-value pair, the key represents the "index" of the subpart
     /// (with the first subpart having index 0), and the value is an FpeConstraintsApplicability
@@ -477,25 +445,19 @@ pub enum FpeConstraintsApplicability {
     ///
     /// This cannot be used with OR parts; instead, specify constraints individually on each
     /// relevant subpart.
-    BySubparts (
-        HashMap<FpeSubpartIndex,FpeConstraintsApplicability>
-    )
+    BySubparts(HashMap<FpeSubpartIndex, FpeConstraintsApplicability>),
 }
 
 /// Structure for specifying (part of) a complex tokenization data type.
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
 #[serde(untagged)]
 pub enum FpeDataPart {
-    Encrypted (
-        FpeEncryptedPart
-    ),
+    Encrypted(FpeEncryptedPart),
     Literal {
         /// The list of possible strings that make up this literal portion of the token.
-        literal: Vec<String>
+        literal: Vec<String>,
     },
-    Compound (
-        FpeCompoundPart
-    )
+    Compound(FpeCompoundPart),
 }
 
 /// A structure for specifying a token part representing a date that occurs after a specified date
@@ -512,7 +474,7 @@ pub enum FpeDate {
         #[serde(default)]
         before: Option<FpeDayMonthYearDate>,
         #[serde(default)]
-        after: Option<FpeDayMonthYearDate>
+        after: Option<FpeDayMonthYearDate>,
     },
     /// Represents a date that consists of a Month subpart and a Day subpart. It is an error to
     /// preserve only the Month part or the Day part.
@@ -521,7 +483,7 @@ pub enum FpeDate {
         #[serde(default)]
         before: Option<FpeDayMonthDate>,
         #[serde(default)]
-        after: Option<FpeDayMonthDate>
+        after: Option<FpeDayMonthDate>,
     },
     /// Represents a date that consists of a Month subpart and a Year subpart. The Year part is
     /// allowed to be preserved; however, the Month part cannot be preserved by itself.
@@ -530,8 +492,8 @@ pub enum FpeDate {
         #[serde(default)]
         before: Option<FpeMonthYearDate>,
         #[serde(default)]
-        after: Option<FpeMonthYearDate>
-    }
+        after: Option<FpeMonthYearDate>,
+    },
 }
 
 /// Possible date-related constraint types for a portion of a complex tokenization data type.
@@ -553,16 +515,12 @@ pub enum FpeDateConstraint {
     /// exact rules depend on the FpeDate variant.
     ///
     /// It is an error to "share" Day, Month, or Year parts across multiple dates.
-    Date (
-        FpeDate
-    ),
+    Date(FpeDate),
     /// Used to indicate that a token part represents a month, day, or year (either as part of a
     /// date, or independently). The part should be a numeric encrypted part that is guaranteed
     /// to either preserve all of its digits or preserve none of them, and cannot be involved in
     /// any Luhn-check constraints.
-    DatePart (
-        FpeDatePart
-    )
+    DatePart(FpeDatePart),
 }
 
 /// Possible date-related constraint types that do not form a complete date (by themselves) for a
@@ -583,7 +541,7 @@ pub enum FpeDatePart {
     Day,
     /// Used to indicate that a token part represents a year, with any zero value being treated as
     /// a leap year. The part should be a two to five digit number.
-    Year
+    Year,
 }
 
 /// A structure for specifying a particular date consisting of a day and a month, for use in an
@@ -594,7 +552,7 @@ pub struct FpeDayMonthDate {
     pub month: u8,
     /// The day, which should be a number from 1 to either 29, 30, or 31, depending on the month
     /// and year. Here, February is treated as having 29 days.
-    pub day: u8
+    pub day: u8,
 }
 
 /// A structure for specifying a particular date consisting of a day, month, and year, for use in
@@ -607,7 +565,7 @@ pub struct FpeDayMonthYearDate {
     pub month: u8,
     /// The day, which should be a number from 1 to either 28, 29, 30, or 31, depending on the
     /// month and year.
-    pub day: u8
+    pub day: u8,
 }
 
 /// Structure of a tokenized portion of a complex tokenization data type.
@@ -627,7 +585,7 @@ pub struct FpeEncryptedPart {
     pub preserve: Option<FpePreserveMask>,
     /// The characters to be masked while performing masked decryption.
     #[serde(default)]
-    pub mask: Option<FpePreserveMask>
+    pub mask: Option<FpePreserveMask>,
 }
 
 /// A structure for specifying a particular date consisting of a month and a year, for use in an
@@ -637,7 +595,7 @@ pub struct FpeMonthYearDate {
     /// The year, which should be a number less than 100000. Zero is treated as a leap year.
     pub year: u32,
     /// The month, which should be a number from 1 to 12.
-    pub month: u8
+    pub month: u8,
 }
 
 /// FPE-specific options.
@@ -645,15 +603,13 @@ pub struct FpeMonthYearDate {
 #[serde(untagged)]
 pub enum FpeOptions {
     /// For specifying basic tokens
-    Basic (
-        FpeOptionsBasic
-    ),
+    Basic(FpeOptionsBasic),
     Advanced {
         /// The structure of the data type.
         format: FpeDataPart,
         /// The user-friendly name for the data type that represents the input data.
-        description: Option<String>
-    }
+        description: Option<String>,
+    },
 }
 
 /// Basic FPE-specific options.
@@ -672,7 +628,7 @@ pub struct FpeOptionsBasic {
     /// Whether encrypted/decrypted data should satisfy LUHN checksum formula.
     pub luhn_check: Option<bool>,
     /// The user-friendly name for the data type that represents the input data.
-    pub name: Option<String>
+    pub name: Option<String>,
 }
 
 /// A structure indicating which indices in an encrypted part to mask or preserve.
@@ -680,16 +636,12 @@ pub struct FpeOptionsBasic {
 #[serde(untagged)]
 pub enum FpePreserveMask {
     /// Indicates that the entire encrypted part is to be preserved or masked.
-    Entire (
-        All
-    ),
+    Entire(All),
     /// Indicates that only certain characters are to be preserved or masked. Indices are
     /// Python-like; i.e., negative indices index from the back of the token portion, with
     /// index -1 being the end of the array. (Indicating that nothing should be preserved
     /// or masked can be done via an empty list, which is the default value for this enum.)
-    ByChars (
-        Vec<isize>
-    )
+    ByChars(Vec<isize>),
 }
 
 /// An index for listing subparts of a compound part to which certain constraints are to be applied.
@@ -709,14 +661,14 @@ pub enum GoogleAccessReason {
     CustomerInitiatedAccess = 5,
     GoogleInitiatedSystemOperation = 6,
     ReasonNotExpected = 7,
-    ModifiedCustomerInitiatedAccess = 8
+    ModifiedCustomerInitiatedAccess = 8,
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct GoogleAccessReasonPolicy {
     pub allow: HashSet<GoogleAccessReason>,
-    pub allow_missing_reason: bool
+    pub allow_missing_reason: bool,
 }
 
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
@@ -724,7 +676,7 @@ pub struct HistoryItem {
     pub id: Uuid,
     pub state: HistoryItemState,
     pub created_at: Time,
-    pub expiry: Time
+    pub expiry: Time,
 }
 
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
@@ -745,12 +697,12 @@ pub struct HistoryItemState {
     pub has_key: bool,
     pub rotation_policy: Option<RotationPolicy>,
     #[serde(default)]
-    pub group_id: Option<Uuid>
+    pub group_id: Option<Uuid>,
 }
 
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
 pub struct HmacOptions {
-    pub minimum_key_length: Option<u32>
+    pub minimum_key_length: Option<u32>,
 }
 
 /// Signing keys used to validate signed JWT tokens.
@@ -759,18 +711,18 @@ pub struct HmacOptions {
 pub enum JwtSigningKeys {
     Stored {
         /// Mapping key ids to DER-encoded public key.
-        keys: HashMap<String,Blob>
+        keys: HashMap<String, Blob>,
     },
     Fetched {
         url: String,
         /// Number of seconds that the service is allowed to cache the fetched keys.
-        cache_duration: u64
-    }
+        cache_duration: u64,
+    },
 }
 
 #[derive(Copy, PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
 pub struct KeyHistoryPolicy {
-    pub undo_time_window: Secs
+    pub undo_time_window: Secs,
 }
 
 /// Linked security objects.
@@ -788,7 +740,7 @@ pub struct KeyLinks {
     #[serde(default)]
     pub subkeys: Vec<Uuid>,
     #[serde(default)]
-    pub parent: Option<Uuid>
+    pub parent: Option<Uuid>,
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
@@ -796,57 +748,57 @@ pub struct KeyMetadataPolicy {
     /// Applies to all objects.
     pub base: MetadataPolicyItem,
     /// Each entry in this map fully overrides `base` for a particular object type.
-    pub for_obj_type: HashMap<ObjectType,MetadataPolicyItem>,
+    pub for_obj_type: HashMap<ObjectType, MetadataPolicyItem>,
     /// What to do with legacy objects that are not compliant with this policy.
     /// Note that objects are not allowed to be created/updated if the result is
     /// not compliant with the policy. Non-compliant legacy objects can only be
     /// updated to comply with the policy (e.g. by adding missing required metadata).
-    pub legacy_objects: LegacyKeyPolicy
+    pub legacy_objects: LegacyKeyPolicy,
 }
 
 /// Operations allowed to be performed on a given key.
 pub use self::key_operations::KeyOperations;
 pub mod key_operations {
-    bitflags_set!{
+    bitflags_set! {
         pub struct KeyOperations: u64 {
-            // If this is set, the key can be used to for signing.
+            ///  If this is set, the key can be used to for signing.
             const SIGN = 0x0000000000000001;
-            //  If this is set, the key can used for verifying a signature.
+            ///  If this is set, the key can used for verifying a signature.
             const VERIFY = 0x0000000000000002;
-            //  If this is set, the key can be used for encryption.
+            ///  If this is set, the key can be used for encryption.
             const ENCRYPT = 0x0000000000000004;
-            //  If this is set, the key can be used for decryption.
+            ///  If this is set, the key can be used for decryption.
             const DECRYPT = 0x0000000000000008;
-            //  If this is set, the key can be used wrapping other keys.
-            //  The key being wrapped must have the EXPORT operation enabled.
+            ///  If this is set, the key can be used wrapping other keys.
+            ///  The key being wrapped must have the EXPORT operation enabled.
             const WRAPKEY = 0x0000000000000010;
-            //  If this is set, the key can be used to unwrap a wrapped key.
+            ///  If this is set, the key can be used to unwrap a wrapped key.
             const UNWRAPKEY = 0x0000000000000020;
-            //  If this is set, the key can be used to derive another key.
+            ///  If this is set, the key can be used to derive another key.
             const DERIVEKEY = 0x0000000000000040;
-            //  If this is set, the key can be used to compute a cryptographic
-            //  Message Authentication Code (MAC) on a message.
+            ///  If this is set, the key can be used to compute a cryptographic
+            ///  Message Authentication Code (MAC) on a message.
             const MACGENERATE = 0x0000000000000080;
-            //  If they is set, the key can be used to verify a MAC.
+            ///  If they is set, the key can be used to verify a MAC.
             const MACVERIFY = 0x0000000000000100;
-            //  If this is set, the value of the key can be retrieved
-            //  with an authenticated request. This shouldn't be set unless
-            //  required. It is more secure to keep the key's value inside DSM only.
+            ///  If this is set, the value of the key can be retrieved
+            ///  with an authenticated request. This shouldn't be set unless
+            ///  required. It is more secure to keep the key's value inside DSM only.
             const EXPORT = 0x0000000000000200;
-            //  Without this operation, management operations like delete, destroy,
-            //  rotate, activate, restore, revoke, revert, update, remove_private, etc.
-            //  cannot be performed by a crypto App.
-            //  A user with access or admin app can still perform these operations.
-            //  This option is only relevant for crypto apps.
+            ///  Without this operation, management operations like delete, destroy,
+            ///  rotate, activate, restore, revoke, revert, update, remove_private, etc.
+            ///  cannot be performed by a crypto App.
+            ///  A user with access or admin app can still perform these operations.
+            ///  This option is only relevant for crypto apps.
             const APPMANAGEABLE = 0x0000000000000400;
-            //  If this is set, audit logs will not be recorded for the key.
-            //   High volume here tries to signify a key that is being used a lot
-            //   and will produce lots of logs. Setting this operation disables
-            //   audit logs for the key.
+            ///  If this is set, audit logs will not be recorded for the key.
+            ///   High volume here tries to signify a key that is being used a lot
+            ///   and will produce lots of logs. Setting this operation disables
+            ///   audit logs for the key.
             const HIGHVOLUME = 0x0000000000000800;
-            //  If this is set, the key can be used for key agreement.
-            //  Both the private and public key should have this option enabled
-            //  to perform an agree operation.
+            ///  If this is set, the key can be used for key agreement.
+            ///  Both the private and public key should have this option enabled
+            ///  to perform an agree operation.
             const AGREEKEY = 0x0000000000001000;
         }
     }
@@ -855,7 +807,7 @@ pub mod key_operations {
 #[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize, Clone)]
 pub struct KmipClientConfig {
     #[serde(default)]
-    pub ignore_unknown_key_ops_for_secrets: Option<bool>
+    pub ignore_unknown_key_ops_for_secrets: Option<bool>,
 }
 
 /// LDAP authorization settings.
@@ -866,7 +818,7 @@ pub struct LdapAuthorizationConfig {
     /// A map from account roles to distinguished names of LDAP groups.
     /// If a DN is specified for an account role, entities with that role
     /// must be a member of the specified LDAP group.
-    pub require_role: HashMap<AccountRole,String>
+    pub require_role: HashMap<AccountRole, String>,
 }
 
 /// Distinguished Name (DN) resolution method. Given a user's email address, a DN resolution method
@@ -877,21 +829,21 @@ pub enum LdapDnResolution {
     /// Transform the user email through a pattern to derive the DN.
     Construct {
         /// For example: "example.com" => "uid={},ou=users,dc=example,dc=com".
-        domain_format: HashMap<String,String>
+        domain_format: HashMap<String, String>,
     },
     /// Search the directory using the LDAP `mail` attribute matching user's email.
     SearchByMail,
     /// Use email in place of DN. This method works with Active Directory if the userPrincipalName
     /// attribute is set for the user. https://docs.microsoft.com/en-us/windows/desktop/ad/naming-properties
     #[serde(rename = "upn")]
-    UserPrincipalName
+    UserPrincipalName,
 }
 
 /// Credentials used by the service to authenticate itself to an LDAP server.
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
 pub struct LdapServiceAccount {
     pub dn: String,
-    pub password: String
+    pub password: String,
 }
 
 #[derive(Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
@@ -906,7 +858,7 @@ pub enum LegacyKeyPolicy {
     /// - VERIFY
     /// - MACVERIFY
     /// - UNWRAPKEY
-    UnprotectOnly
+    UnprotectOnly,
 }
 
 /// LMS specific options
@@ -917,15 +869,13 @@ pub struct LmsOptions {
     /// The height of the secondary tree
     pub l2_height: u32,
     /// The hash function to use
-    pub digest: Option<DigestAlgorithm>
+    pub digest: Option<DigestAlgorithm>,
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum MetadataDurationConstraint {
-    Forbidden {
-
-    },
+    Forbidden {},
     Required {
         /// If specified, the value (typically a date) is restricted to be in a
         /// range expressed in terms of duration with respect to some known point
@@ -933,13 +883,13 @@ pub enum MetadataDurationConstraint {
         /// for `deactivation_date`, then the user must specify a deactivation date
         /// that is within 30 and 180 days of security object's creation time.
         #[serde(default)]
-        allowed_values: RestrictedDuration
-    }
+        allowed_values: RestrictedDuration,
+    },
 }
 
 #[derive(Debug, PartialEq, Eq, Default, Serialize, Deserialize, Clone)]
 pub struct MetadataPolicyItem {
-    pub custom_metadata: HashMap<String,MetadataStringConstraint>,
+    pub custom_metadata: HashMap<String, MetadataStringConstraint>,
     pub description: Option<MetadataStringConstraint>,
     /// If a restricted duration is specified, it is enforced w.r.t object creation time.
     pub deactivation_date: Option<MetadataDurationConstraint>,
@@ -947,47 +897,41 @@ pub struct MetadataPolicyItem {
     /// NOTE: Specifying a minimum duration for this field may not be a good
     /// idea since it would not be possible to create a key and start using it
     /// immediately in the affected group(s).
-    pub activation_date: Option<MetadataDurationConstraint>
+    pub activation_date: Option<MetadataDurationConstraint>,
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum MetadataStringConstraint {
-    Forbidden {
-
-    },
+    Forbidden {},
     Required {
         /// If set to `true`, the value must have a length > 0 after trimming
         /// leading and trailing whitespace characters.
         non_empty_after_trim: bool,
         /// If not specified or empty, it will not impose any restrictions on the value.
-        allowed_values: HashSet<String>
-    }
+        allowed_values: HashSet<String>,
+    },
 }
 
 /// A challenge used for multi-factor authentication.
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
 pub struct MfaChallengeResponse {
     pub u2f_challenge: String,
-    pub u2f_keys: Vec<U2fRegisteredKey>
+    pub u2f_keys: Vec<U2fRegisteredKey>,
 }
 
 /// Specifies the Mask Generating Function (MGF) to use.
 #[derive(Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum Mgf {
-    Mgf1 {
-        hash: DigestAlgorithm
-    }
+    Mgf1 { hash: DigestAlgorithm },
 }
 
 /// MGF policy.
 #[derive(Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum MgfPolicy {
-    Mgf1 {
-        hash: Option<DigestAlgorithm>
-    }
+    Mgf1 { hash: Option<DigestAlgorithm> },
 }
 
 /// OAuth scope.
@@ -997,7 +941,7 @@ pub enum OauthScope {
     App,
     OpenID,
     Email,
-    Profile
+    Profile,
 }
 
 /// The origin of a security object - where it was created / generated.
@@ -1005,7 +949,7 @@ pub enum OauthScope {
 pub enum ObjectOrigin {
     FortanixHSM,
     Transient,
-    External
+    External,
 }
 
 /// Type of security object.
@@ -1026,13 +970,11 @@ pub enum ObjectType {
     Seed,
     Lms,
     Certificate,
-    Pbe
+    Pbe,
 }
 
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
-pub struct OpaqueOptions {
-
-}
+pub struct OpaqueOptions {}
 
 #[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize, Clone)]
 pub struct Pkcs11ClientConfig {
@@ -1047,7 +989,7 @@ pub struct Pkcs11ClientConfig {
     #[serde(default)]
     pub opaque_objects_are_not_certificates: Option<bool>,
     #[serde(default)]
-    pub max_concurrent_requests_per_slot: Option<usize>
+    pub max_concurrent_requests_per_slot: Option<usize>,
 }
 
 #[derive(Debug, Eq, PartialEq, Copy, Serialize, Deserialize, Clone)]
@@ -1057,27 +999,21 @@ pub enum Pkcs8Mode {
     PbeWithSHAAnd3KeyTripleDesCbc,
     PbeWithSHAAnd2KeyTripleDesCbc,
     Pbes2WithPBKDF2AndKeyDes,
-    Pbes2WithPBKDF2AndKeyTripleDes
+    Pbes2WithPBKDF2AndKeyTripleDes,
 }
 
 /// A security principal.
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum Principal {
-    App (
-        Uuid
-    ),
-    User (
-        Uuid
-    ),
-    Plugin (
-        Uuid
-    ),
+    App(Uuid),
+    User(Uuid),
+    Plugin(Uuid),
     /// UserViaApp signifies a user authorizing some app to act on its behalf through OAuth.
     UserViaApp {
         user_id: Uuid,
-        scopes: HashSet<OauthScope>
-    }
+        scopes: HashSet<OauthScope>,
+    },
 }
 
 /// If enabled, the public key will be available publicly (without authentication) through the GetPublicKey API.
@@ -1086,9 +1022,9 @@ pub enum Principal {
 pub enum PublishPublicKeyConfig {
     Enabled {
         /// Additionally list the previous version of the key if not compromised.
-        list_previous_version: bool
+        list_previous_version: bool,
     },
-    Disabled
+    Disabled,
 }
 
 /// Quorum approval policy.
@@ -1097,7 +1033,7 @@ pub struct Quorum {
     pub n: usize,
     pub members: Vec<QuorumPolicy>,
     #[serde(flatten)]
-    pub config: ApprovalAuthConfig
+    pub config: ApprovalAuthConfig,
 }
 
 /// Approval policy.
@@ -1108,13 +1044,13 @@ pub struct QuorumPolicy {
     #[serde(default)]
     pub user: Option<Uuid>,
     #[serde(default)]
-    pub app: Option<Uuid>
+    pub app: Option<Uuid>,
 }
 
 #[derive(Debug, PartialEq, Eq, Default, Serialize, Deserialize, Clone)]
 pub struct RestrictedDuration {
     pub min: Option<TimeSpan>,
-    pub max: Option<TimeSpan>
+    pub max: Option<TimeSpan>,
 }
 
 /// Reason for revoking a key.
@@ -1124,7 +1060,7 @@ pub struct RevocationReason {
     /// Message is used exclusively for audit trail/logging purposes and MAY contain additional
     /// information about why the object was revoked.
     pub message: Option<String>,
-    pub compromise_occurance_date: Option<Time>
+    pub compromise_occurance_date: Option<Time>,
 }
 
 /// Reasons to revoke a security object.
@@ -1136,18 +1072,14 @@ pub enum RevocationReasonCode {
     AffiliationChanged,
     Superseded,
     CessationOfOperation,
-    PrivilegeWithdrawn
+    PrivilegeWithdrawn,
 }
 
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum RotationInterval {
-    IntervalDays (
-        u32
-    ),
-    IntervalMonths (
-        u32
-    )
+    IntervalDays(u32),
+    IntervalMonths(u32),
 }
 
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
@@ -1156,7 +1088,7 @@ pub struct RotationPolicy {
     pub interval: Option<RotationInterval>,
     #[serde(default)]
     pub effective_at: Option<Time>,
-    pub deactivate_rotated_key: bool
+    pub deactivate_rotated_key: bool,
 }
 
 /// Type of padding to use for RSA encryption. The use of PKCS#1 v1.5 padding is strongly
@@ -1168,36 +1100,26 @@ pub struct RotationPolicy {
 pub enum RsaEncryptionPadding {
     /// Optimal Asymmetric Encryption Padding (PKCS#1 v2.1).
     Oaep {
-        mgf: Mgf
+        mgf: Mgf,
     },
     /// PKCS#1 v1.5 padding.
-    Pkcs1V15 {
-
-    },
-    RawDecrypt {
-
-    }
+    Pkcs1V15 {},
+    RawDecrypt {},
 }
 
 /// RSA encryption padding policy.
 #[derive(Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum RsaEncryptionPaddingPolicy {
-    Oaep {
-        mgf: Option<MgfPolicy>
-    },
-    Pkcs1V15 {
-
-    },
-    RawDecrypt {
-
-    }
+    Oaep { mgf: Option<MgfPolicy> },
+    Pkcs1V15 {},
+    RawDecrypt {},
 }
 
 /// Constraints on RSA encryption parameters. In general, if a constraint is not specified, anything is allowed.
 #[derive(Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
 pub struct RsaEncryptionPolicy {
-    pub padding: Option<RsaEncryptionPaddingPolicy>
+    pub padding: Option<RsaEncryptionPaddingPolicy>,
 }
 
 /// RSA-specific options.
@@ -1224,7 +1146,7 @@ pub struct RsaOptions {
     /// If (part of) a constraint is not specified, anything is allowed for that constraint.
     pub signature_policy: Vec<RsaSignaturePolicy>,
     #[serde(default)]
-    pub minimum_key_length: Option<u32>
+    pub minimum_key_length: Option<u32>,
 }
 
 /// Type of padding to use for RSA signatures. The padding specified must adhere to the key's
@@ -1233,44 +1155,34 @@ pub struct RsaOptions {
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum RsaSignaturePadding {
     /// Probabilistic Signature Scheme (PKCS#1 v2.1).
-    Pss {
-        mgf: Mgf
-    },
+    Pss { mgf: Mgf },
     /// PKCS#1 v1.5 padding.
-    Pkcs1V15 {
-
-    }
+    Pkcs1V15 {},
 }
 
 /// RSA signature padding policy.
 #[derive(Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum RsaSignaturePaddingPolicy {
-    Pss {
-        mgf: Option<MgfPolicy>
-    },
-    Pkcs1V15 {
-
-    }
+    Pss { mgf: Option<MgfPolicy> },
+    Pkcs1V15 {},
 }
 
 /// Constraints on RSA signature parameters. In general, if a constraint is not specified, anything is allowed.
 #[derive(Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
 pub struct RsaSignaturePolicy {
-    pub padding: Option<RsaSignaturePaddingPolicy>
+    pub padding: Option<RsaSignaturePaddingPolicy>,
 }
 
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
-pub struct SecretOptions {
-
-}
+pub struct SecretOptions {}
 
 pub type Secs = u64;
 
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
 pub struct SeedOptions {
     pub cipher_mode: Option<CipherMode>,
-    pub random_iv: Option<bool>
+    pub random_iv: Option<bool>,
 }
 
 /// A request to sign data (or hash value) using an asymmetric key.
@@ -1285,7 +1197,7 @@ pub struct SignRequest {
     /// To reduce request size and avoid reaching the request size limit, prefer `hash`.
     pub data: Option<Blob>,
     pub mode: Option<SignatureMode>,
-    pub deterministic_signature: Option<bool>
+    pub deterministic_signature: Option<bool>,
 }
 
 /// Result of sign operation.
@@ -1294,16 +1206,14 @@ pub struct SignResponse {
     /// Key id is returned for non-transient keys.
     #[serde(default)]
     pub kid: Option<Uuid>,
-    pub signature: Blob
+    pub signature: Blob,
 }
 
 /// Signature mode.
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
 #[serde(untagged)]
 pub enum SignatureMode {
-    Rsa (
-        RsaSignaturePadding
-    )
+    Rsa(RsaSignaturePadding),
 }
 
 #[derive(Eq, PartialEq, Debug, Serialize, Deserialize, Clone)]
@@ -1320,7 +1230,7 @@ pub struct Sobject {
     pub created_at: Time,
     pub creator: Principal,
     #[serde(default)]
-    pub custom_metadata: Option<HashMap<String,String>>,
+    pub custom_metadata: Option<HashMap<String, String>>,
     #[serde(default)]
     pub deactivation_date: Option<Time>,
     #[serde(default)]
@@ -1389,26 +1299,17 @@ pub struct Sobject {
     #[serde(default)]
     pub value: Option<Blob>,
     #[serde(default)]
-    pub group_id: Option<Uuid>
+    pub group_id: Option<Uuid>,
 }
 
 /// Uniquely identifies a persisted or transient sobject.
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum SobjectDescriptor {
-    Kid (
-        Uuid
-    ),
-    Name (
-        String
-    ),
-    TransientKey (
-        Blob
-    ),
-    Inline {
-        value: Blob,
-        obj_type: ObjectType
-    }
+    Kid(Uuid),
+    Name(String),
+    TransientKey(Blob),
+    Inline { value: Blob, obj_type: ObjectType },
 }
 
 #[derive(Debug, Eq, PartialEq, Copy, Serialize, Deserialize, Clone)]
@@ -1418,24 +1319,16 @@ pub enum SobjectState {
     Deactivated,
     Compromised,
     Destroyed,
-    Deleted
+    Deleted,
 }
 
 #[derive(Debug, Copy, PartialEq, Eq, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum TimeSpan {
-    Seconds (
-        u32
-    ),
-    Minutes (
-        u32
-    ),
-    Hours (
-        u32
-    ),
-    Days (
-        u32
-    )
+    Seconds(u32),
+    Minutes(u32),
+    Hours(u32),
+    Days(u32),
 }
 
 /// TLS settings.
@@ -1448,8 +1341,8 @@ pub enum TlsConfig {
         validate_hostname: bool,
         ca: CaConfig,
         client_key: Option<Blob>,
-        client_cert: Option<Blob>
-    }
+        client_cert: Option<Blob>,
+    },
 }
 
 /// Request for second factor authentication with a U2f device.
@@ -1458,7 +1351,7 @@ pub enum TlsConfig {
 pub struct U2fAuthRequest {
     pub key_handle: Blob,
     pub signature_data: Blob,
-    pub client_data: Blob
+    pub client_data: Blob,
 }
 
 /// Description of a registered U2F device.
@@ -1466,10 +1359,10 @@ pub struct U2fAuthRequest {
 #[serde(rename_all = "camelCase")]
 pub struct U2fRegisteredKey {
     pub key_handle: String,
-    pub version: String
+    pub version: String,
 }
 
-singleton_backcompat!{
+singleton_backcompat! {
     /// User's role in a group.
     #[derive(Debug, Eq, PartialEq, Copy, Clone)]
     #[serde(rename_all = "UPPERCASE")]
@@ -1494,7 +1387,7 @@ pub struct VerifyRequest {
     pub data: Option<Blob>,
     pub mode: Option<SignatureMode>,
     /// The signature to verify.
-    pub signature: Blob
+    pub signature: Blob,
 }
 
 /// Result of verifying a signature or MAC.
@@ -1504,6 +1397,5 @@ pub struct VerifyResponse {
     #[serde(default)]
     pub kid: Option<Uuid>,
     /// True if the signature verified and false if it did not.
-    pub result: bool
+    pub result: bool,
 }
-

--- a/src/generated/common_generated.rs
+++ b/src/generated/common_generated.rs
@@ -5,12 +5,787 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::*;
-use serde::{Deserialize, Serialize};
+
+/// Role of a user or app in an account.
+#[derive(Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum AccountRole {
+    AdminUser,
+    MemberUser,
+    AuditorUser,
+    AdminApp,
+    CryptoApp
+}
+
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+pub struct AesOptions {
+    pub key_sizes: Option<Vec<u32>>,
+    pub fpe: Option<FpeOptions>,
+    pub tag_length: Option<i32>,
+    pub cipher_mode: Option<CipherMode>,
+    pub random_iv: Option<bool>,
+    pub iv_length: Option<i32>
+}
+
+/// A cryptographic algorithm.
+#[derive(Debug, Eq, PartialEq, Copy, Hash, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum Algorithm {
+    Aes,
+    Des,
+    Des3,
+    Seed,
+    Rsa,
+    Dsa,
+    Ec,
+    Lms,
+    Hmac,
+    LedaBeta,
+    Round5Beta,
+    Pbe
+}
+
+/// A helper enum with a single variant, All, which indicates that something should apply to an
+/// entire part. (This is here mainly to allow other untagged enums to work properly.)
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "lowercase")]
+pub enum All {
+    All
+}
+
+/// Operations allowed to be performed by an app.
+pub use self::app_permissions::AppPermissions;
+pub mod app_permissions {
+    bitflags_set!{
+        pub struct AppPermissions: u64 {
+            const SIGN = 0x0000000000000001;
+            const VERIFY = 0x0000000000000002;
+            const ENCRYPT = 0x0000000000000004;
+            const DECRYPT = 0x0000000000000008;
+            const WRAPKEY = 0x0000000000000010;
+            const UNWRAPKEY = 0x0000000000000020;
+            const DERIVEKEY = 0x0000000000000040;
+            const MACGENERATE = 0x0000000000000080;
+            const MACVERIFY = 0x0000000000000100;
+            const EXPORT = 0x0000000000000200;
+            const MANAGE = 0x0000000000000400;
+            const AGREEKEY = 0x0000000000000800;
+            const MASKDECRYPT = 0x0000000000001000;
+            const AUDIT = 0x0000000000002000;
+        }
+    }
+}
+
+/// Authentication requirements for approval request reviewers.
+#[derive(Copy, PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+pub struct ApprovalAuthConfig {
+    pub require_password: bool,
+    pub require_2fa: bool
+}
+
+/// LDAP authentication settings.
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+pub struct AuthConfigLdap {
+    pub name: String,
+    pub icon_url: String,
+    pub ldap_url: String,
+    pub dn_resolution: LdapDnResolution,
+    pub tls: TlsConfig,
+    #[serde(default)]
+    pub base_dn: Option<String>,
+    #[serde(default)]
+    pub user_object_class: Option<String>,
+    #[serde(default)]
+    pub service_account: Option<LdapServiceAccount>,
+    #[serde(default)]
+    pub authorization: Option<LdapAuthorizationConfig>
+}
+
+/// CA settings.
+#[derive(PartialEq, Eq, Hash, Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum CaConfig {
+    CaSet (
+        CaSet
+    ),
+    Pinned (
+        Vec<Blob>
+    )
+}
+
+/// Predefined CA sets.
+#[derive(PartialEq, Eq, Hash, Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum CaSet {
+    GlobalRoots
+}
+
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+pub struct CertificateOptions {
+
+}
+
+/// Cipher mode used for symmetric key algorithms.
+#[derive(Debug, Eq, PartialEq, Copy, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum CipherMode {
+    Ecb,
+    Cbc,
+    CbcNoPad,
+    Cfb,
+    Ofb,
+    Ctr,
+    Gcm,
+    Ccm,
+    Kw,
+    Kwp,
+    Ff1
+}
+
+#[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize, Clone)]
+pub struct ClientConfigurations {
+    /// NOTE: not all clients use `common` configurations.
+    #[serde(default)]
+    pub common: Option<CommonClientConfig>,
+    #[serde(default)]
+    pub pkcs11: Option<Pkcs11ClientConfig>,
+    #[serde(default)]
+    pub kmip: Option<KmipClientConfig>
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+pub struct ClientConfigurationsRequest {
+    pub common: Option<Option<CommonClientConfig>>,
+    pub pkcs11: Option<Option<Pkcs11ClientConfig>>,
+    pub kmip: Option<Option<KmipClientConfig>>
+}
+
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "snake_case", tag = "mode")]
+pub enum ClientFileLogging {
+    Enabled (
+        ClientFileLoggingConfig
+    ),
+    Disabled
+}
+
+#[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize, Clone)]
+pub struct ClientFileLoggingConfig {
+    #[serde(default)]
+    pub path: Option<String>,
+    #[serde(default)]
+    pub file_size_kb: Option<u64>,
+    #[serde(default)]
+    pub max_files: Option<u32>
+}
+
+#[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize, Clone)]
+pub struct ClientLogConfig {
+    #[serde(default)]
+    pub system: Option<bool>,
+    #[serde(default)]
+    pub file: Option<ClientFileLogging>,
+    #[serde(default)]
+    pub level: Option<String>
+}
+
+#[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize, Clone)]
+pub struct CommonClientConfig {
+    #[serde(default)]
+    pub retry_timeout_millis: Option<u64>,
+    #[serde(default)]
+    pub log: Option<ClientLogConfig>,
+    #[serde(default)]
+    pub h2_num_connections: Option<usize>
+}
+
+/// `CipherMode` or `RsaEncryptionPadding`, depending on the encryption algorithm.
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
+#[serde(untagged)]
+pub enum CryptMode {
+    Symmetric (
+        CipherMode
+    ),
+    Rsa (
+        RsaEncryptionPadding
+    ),
+    Pkcs8Mode (
+        Pkcs8Mode
+    )
+}
+
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+pub struct CryptographicPolicy {
+    pub aes: Option<AesOptions>,
+    pub des: Option<DesOptions>,
+    pub des3: Option<Des3Options>,
+    pub seed: Option<SeedOptions>,
+    pub rsa: Option<RsaOptions>,
+    pub dsa: Option<DsaOptions>,
+    pub ec: Option<EcOptions>,
+    pub opaque: Option<OpaqueOptions>,
+    pub hmac: Option<HmacOptions>,
+    pub secret: Option<SecretOptions>,
+    pub certificate: Option<CertificateOptions>,
+    pub key_ops: Option<KeyOperations>,
+    pub legacy_policy: Option<LegacyKeyPolicy>
+}
+
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+pub struct Des3Options {
+    pub key_sizes: Option<Vec<u32>>,
+    pub cipher_mode: Option<CipherMode>,
+    pub random_iv: Option<bool>,
+    pub iv_length: Option<i32>
+}
+
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+pub struct DesOptions {
+    pub cipher_mode: Option<CipherMode>,
+    pub random_iv: Option<bool>
+}
+
+/// A hash algorithm.
+#[derive(Debug, Eq, PartialEq, Copy, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum DigestAlgorithm {
+    Blake2b256,
+    Blake2b384,
+    Blake2b512,
+    Blake2s256,
+    Ripemd160,
+    Ssl3,
+    Sha1,
+    Sha224,
+    Sha256,
+    Sha384,
+    Sha512,
+    Streebog256,
+    Streebog512,
+    Sha3_224,
+    Sha3_256,
+    Sha3_384,
+    Sha3_512
+}
+
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+pub struct DsaOptions {
+    pub subgroup_size: Option<u32>
+}
+
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+pub struct EcOptions {
+    pub elliptic_curves: Option<Vec<EllipticCurve>>
+}
+
+/// Identifies a standardized elliptic curve.
+#[derive(Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
+pub enum EllipticCurve {
+    X25519,
+    Ed25519,
+    X448,
+    SecP192K1,
+    SecP224K1,
+    SecP256K1,
+    NistP192,
+    NistP224,
+    NistP256,
+    NistP384,
+    NistP521,
+    Gost256A
+}
+
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+#[serde(untagged)]
+pub enum ExternalKeyId {
+    Pkcs11 {
+        id: Blob,
+        label: Blob
+    },
+    Fortanix {
+        id: Uuid
+    },
+    AwsKms {
+        key_arn: String,
+        key_id: String
+    },
+    AzureKeyVault {
+        version: Uuid,
+        label: String
+    },
+    GcpKeyRing {
+        version: u32,
+        label: String
+    },
+    Wrapped {
+
+    }
+}
+
+/// This describes an external object. Virtual keys in SDKMS store this information instead of the key material.
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+pub struct ExternalSobjectInfo {
+    /// The ID of the external object in the external HSM.
+    pub id: ExternalKeyId,
+    /// The group which corresponds to the external HSM.
+    pub hsm_group_id: Uuid
+}
+
+/// The character set to use for an encrypted portion of a complex tokenization data type.
+/// Characters should be specified as a list of pairs, where each pair [a, b] represents the
+/// range of characters from a to b, with both bounds being inclusive. A single character can
+/// be specified as [c, c].
+///
+/// Normally, each character is assigned a numeric value for FF1. The first character is
+/// assigned a value of 0, and subsequent characters are assigned values of 1, 2, and so on,
+/// up to the size of the character set. Note that the order of the ranges matters; characters
+/// appearing in later ranges are assigned higher numerical values compared to earlier
+/// characters. For instance, in the character set [['a', 'z'], ['0', '9']], the digits '0' to
+/// '9' are assigned values from 26 to 35, since they are listed after the 'a' to 'z' range.
+///
+/// In any case, ranges should not overlap with each other, and should not contain surrogate
+/// codepoints.
+pub type FpeCharSet = Vec<[char; 2]>;
+
+/// Structure of a compound portion of a complex tokenization data type, itself composed of
+/// smaller parts.
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+#[serde(untagged)]
+pub enum FpeCompoundPart {
+    /// Represents an OR of multiple structures.
+    Or {
+        /// The actual subparts that make up this compound part.
+        or: Vec<FpeDataPart>,
+        /// Additional constraints that the token type must satisfy.
+        #[serde(default)]
+        constraints: Option<FpeConstraints>,
+        /// Whether the entire OR should be preserved as-is (i.e., not tokenized). If this is
+        /// set, any descendant subparts cannot contain any preserve-related fields set.
+        #[serde(default)]
+        preserve: Option<bool>,
+        /// Whether the entire OR should be masked when doing masked decryption. If this is set,
+        /// any descendant subparts cannot contain any mask-related fields set.
+        #[serde(default)]
+        mask: Option<bool>,
+        /// The minimum allowed length for this part (in chars).
+        #[serde(default)]
+        min_length: Option<u32>,
+        /// The maximum allowed length for this part (in chars).
+        #[serde(default)]
+        max_length: Option<u32>
+    },
+    /// Represents a concatenation of multiple structures (in a particular order).
+    Concat {
+        /// The actual subparts that make up this compound part, in order.
+        concat: Vec<FpeDataPart>,
+        /// Additional constraints that the token type must satisfy.
+        #[serde(default)]
+        constraints: Option<FpeConstraints>,
+        /// Whether the entire concat should be preserved as-is (i.e., not tokenized). If this is
+        /// set, any descendant subparts cannot contain any preserve-related fields set.
+        #[serde(default)]
+        preserve: Option<bool>,
+        /// Whether the entire concat should be masked when doing masked decryption. If this is
+        /// set, any descendant subparts cannot contain any mask-related fields set.
+        #[serde(default)]
+        mask: Option<bool>,
+        /// The minimum allowed length for this part (in chars).
+        #[serde(default)]
+        min_length: Option<u32>,
+        /// The maximum allowed length for this part (in chars).
+        #[serde(default)]
+        max_length: Option<u32>
+    },
+    /// Indicates a part that is possibly repeated multiple times.
+    Multiple {
+        /// The subpart that may be repeated.
+        multiple: Box<FpeDataPart>,
+        /// The minimum number of times the subpart can be repeated.
+        min_repetitions: Option<usize>,
+        /// The maximum number of times the subpart can be repeated.
+        max_repetitions: Option<usize>,
+        /// Additional constraints that the token type must satisfy.
+        #[serde(default)]
+        constraints: Option<FpeConstraints>,
+        /// Whether the entire Multiple should be preserved as-is (i.e., not tokenized). If this
+        /// is set, the `multiple` subpart and its descendants cannot contain any preserve-related
+        /// fields set.
+        #[serde(default)]
+        preserve: Option<bool>,
+        /// Whether the entire Multiple should be masked when doing masked decryption. If this is
+        /// set, the `multiple` subpart and its descendants cannot contain any mask-related fields
+        /// set.
+        #[serde(default)]
+        mask: Option<bool>,
+        /// The minimum allowed length for this part (in chars).
+        #[serde(default)]
+        min_length: Option<u32>,
+        /// The maximum allowed length for this part (in chars).
+        #[serde(default)]
+        max_length: Option<u32>
+    }
+}
+
+/// Constraints on a portion of a complex tokenization data type.
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+pub struct FpeConstraints {
+    /// Whether the token part should satisfy the Luhn checksum. It is an error to apply this
+    /// constraint to non-numeric parts, or for an encrypted part to be under more than one
+    /// Luhn check constraint. Also, if an encrypted part has a Luhn check constraint applied
+    /// to it and may contain at least one digit that is not preserved, it must not specify
+    /// any other constraints.
+    #[serde(default)]
+    pub luhn_check: Option<bool>,
+    /// Number that the token part should be greater than. This constraint can only be
+    /// specified on (non-compound) numeric encrypted parts guaranteed to preserve either
+    /// everything or nothing at all.
+    #[serde(default)]
+    pub num_gt: Option<usize>,
+    /// Number that the token part should be smaller than. This constraint can only be
+    /// specified on (non-compound) numeric encrypted parts guaranteed to preserve either
+    /// everything or nothing at all.
+    #[serde(default)]
+    pub num_lt: Option<usize>,
+    /// Numbers that the token part should not be equal to. It is an error to apply this
+    /// constraint to non-numeric parts.
+    #[serde(default)]
+    pub num_ne: Option<Vec<usize>>,
+    /// Specifies that this portion is supposed to represent a date, or part of one. If used,
+    /// no other constraints can be specified on this part.
+    #[serde(default)]
+    pub date: Option<FpeDateConstraint>,
+    /// The subparts to apply the constaints to. If not specified, the constraints will be
+    /// applied to all subparts (recursively).
+    pub applies_to: FpeConstraintsApplicability
+}
+
+/// A structure indicating which subparts to which to apply a set of constraints.
+#[derive(Eq, PartialEq, Debug, Serialize, Deserialize, Clone)]
+#[serde(untagged)]
+pub enum FpeConstraintsApplicability {
+    /// Indicates that the constraints apply to the entire part (i.e., all of its subparts),
+    /// including any descendants. This is the default value for this enum and the only option
+    /// available for FpeEncryptedPart, literal, and OR subparts.
+    Simple (
+        All
+    ),
+    /// An object representing the individual subparts that the constraints should apply to. This
+    /// is a BTreeMap where for each key-value pair, the key represents the "index" of the subpart
+    /// (with the first subpart having index 0), and the value is an FpeConstraintsApplicability
+    /// instance. Note that a Multiple part only allows for one possible key-value pair, since it
+    /// only contains one subpart.
+    ///
+    /// This cannot be used with OR parts; instead, specify constraints individually on each
+    /// relevant subpart.
+    BySubparts (
+        HashMap<FpeSubpartIndex,FpeConstraintsApplicability>
+    )
+}
+
+/// Structure for specifying (part of) a complex tokenization data type.
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+#[serde(untagged)]
+pub enum FpeDataPart {
+    Encrypted (
+        FpeEncryptedPart
+    ),
+    Literal {
+        /// The list of possible strings that make up this literal portion of the token.
+        literal: Vec<String>
+    },
+    Compound (
+        FpeCompoundPart
+    )
+}
+
+/// A structure for specifying a token part representing a date that occurs after a specified date
+/// and/or occurs before a specified date. Depending on the subparts that make up the date, one of
+/// the three options is used.
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+pub enum FpeDate {
+    /// Represents a date that consists of a Month subpart, a Day subpart, and a Year subpart. The
+    /// Year part is allowed to be preserved, and the Day and Month parts are allowed to be
+    /// preserved together. (The Day part cannot be preserved if the Month part is not, and vice
+    /// versa.)
+    #[serde(rename = "dmy_date")]
+    DayMonthYear {
+        #[serde(default)]
+        before: Option<FpeDayMonthYearDate>,
+        #[serde(default)]
+        after: Option<FpeDayMonthYearDate>
+    },
+    /// Represents a date that consists of a Month subpart and a Day subpart. It is an error to
+    /// preserve only the Month part or the Day part.
+    #[serde(rename = "month_day_date")]
+    MonthDay {
+        #[serde(default)]
+        before: Option<FpeDayMonthDate>,
+        #[serde(default)]
+        after: Option<FpeDayMonthDate>
+    },
+    /// Represents a date that consists of a Month subpart and a Year subpart. The Year part is
+    /// allowed to be preserved; however, the Month part cannot be preserved by itself.
+    #[serde(rename = "month_year_date")]
+    MonthYear {
+        #[serde(default)]
+        before: Option<FpeMonthYearDate>,
+        #[serde(default)]
+        after: Option<FpeMonthYearDate>
+    }
+}
+
+/// Possible date-related constraint types for a portion of a complex tokenization data type.
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+#[serde(untagged)]
+pub enum FpeDateConstraint {
+    /// Used to indicate that a token part represents a date, which should occur before and/or
+    /// after any specified bounds. The part should be a concatenation that contains either
+    /// - a Day part and a Month part
+    /// - a Month part and a Year part
+    /// - a Day part, a Month part, and a Year part
+    /// (with this constraint applying to those subparts). Each of the three choices above
+    /// corresponds to a particular FpeDate variant; using the wrong variant is an error.
+    /// Furthermore, the individual Month, Day, and/or Year parts that comprise the date cannot
+    /// appear under Or or Multiple compound part descendants of the overall Date part (i.e.,
+    /// when applying the Date constraint, the "paths" from the Date part to the Month, Day,
+    /// and/or Year parts can only "go through" concatenations, and not "through" Or or Multiple
+    /// parts). Those parts also have additional restrictions on how they may be preserved; the
+    /// exact rules depend on the FpeDate variant.
+    ///
+    /// It is an error to "share" Day, Month, or Year parts across multiple dates.
+    Date (
+        FpeDate
+    ),
+    /// Used to indicate that a token part represents a month, day, or year (either as part of a
+    /// date, or independently). The part should be a numeric encrypted part that is guaranteed
+    /// to either preserve all of its digits or preserve none of them, and cannot be involved in
+    /// any Luhn-check constraints.
+    DatePart (
+        FpeDatePart
+    )
+}
+
+/// Possible date-related constraint types that do not form a complete date (by themselves) for a
+/// complex tokenization data type.
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "lowercase")]
+pub enum FpeDatePart {
+    /// Used to indicate that a token part represents a month. The part should be a number from 1
+    /// to 12, have its min_length field be at least 1, and have its max_length field be 2. Any
+    /// leading zero should be removed (unless the part is always 2 digits long, in which case a
+    /// leading zero may be needed).
+    Month,
+    /// Used to indicate that a token part represents a day. The part should be a number from 1 to
+    /// 31, have its min_length field be at least 1, and have its max_length field be 2. Any
+    /// leading zero should be removed (unless the part is always 2 digits long, in which case a
+    /// leading zero may be needed). Further restrictions apply when the Day part occurs within a
+    /// date; for instance, a date of 2/29/2000 is fine, but 4/31 is not.
+    Day,
+    /// Used to indicate that a token part represents a year, with any zero value being treated as
+    /// a leap year. The part should be a two to five digit number.
+    Year
+}
+
+/// A structure for specifying a particular date consisting of a day and a month, for use in an
+/// FpeDate structure.
+#[derive(PartialEq, Eq, Debug, PartialOrd, Ord, Serialize, Deserialize, Clone)]
+pub struct FpeDayMonthDate {
+    /// The month, which should be a number from 1 to 12.
+    pub month: u8,
+    /// The day, which should be a number from 1 to either 29, 30, or 31, depending on the month
+    /// and year. Here, February is treated as having 29 days.
+    pub day: u8
+}
+
+/// A structure for specifying a particular date consisting of a day, month, and year, for use in
+/// an FpeDate structure.
+#[derive(PartialEq, Eq, Debug, PartialOrd, Ord, Serialize, Deserialize, Clone)]
+pub struct FpeDayMonthYearDate {
+    /// The year, which should be a number less than 100000. Zero is treated as a leap year.
+    pub year: u32,
+    /// The month, which should be a number from 1 to 12.
+    pub month: u8,
+    /// The day, which should be a number from 1 to either 28, 29, 30, or 31, depending on the
+    /// month and year.
+    pub day: u8
+}
+
+/// Structure of a tokenized portion of a complex tokenization data type.
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+pub struct FpeEncryptedPart {
+    /// The minimum allowed length for this part (in chars).
+    pub min_length: u32,
+    /// The maximum allowed length for this part (in chars).
+    pub max_length: u32,
+    /// The character set to use for this part.
+    pub char_set: FpeCharSet,
+    /// Additional constraints that the token type must satisfy.
+    #[serde(default)]
+    pub constraints: Option<FpeConstraints>,
+    /// The characters to be preserved while encrypting or decrypting.
+    #[serde(default)]
+    pub preserve: Option<FpePreserveMask>,
+    /// The characters to be masked while performing masked decryption.
+    #[serde(default)]
+    pub mask: Option<FpePreserveMask>
+}
+
+/// A structure for specifying a particular date consisting of a month and a year, for use in an
+/// FpeDate structure.
+#[derive(PartialEq, Eq, Debug, PartialOrd, Ord, Serialize, Deserialize, Clone)]
+pub struct FpeMonthYearDate {
+    /// The year, which should be a number less than 100000. Zero is treated as a leap year.
+    pub year: u32,
+    /// The month, which should be a number from 1 to 12.
+    pub month: u8
+}
+
+/// FPE-specific options.
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+#[serde(untagged)]
+pub enum FpeOptions {
+    /// For specifying basic tokens
+    Basic (
+        FpeOptionsBasic
+    ),
+    Advanced {
+        /// The structure of the data type.
+        format: FpeDataPart,
+        /// The user-friendly name for the data type that represents the input data.
+        description: Option<String>
+    }
+}
+
+/// Basic FPE-specific options.
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+pub struct FpeOptionsBasic {
+    /// The base for input data.
+    pub radix: u32,
+    /// The minimum allowed length for the input data.
+    pub min_length: u32,
+    /// The maximum allowed length for the input data.
+    pub max_length: u32,
+    /// The list of indices of characters to be preserved while performing encryption/decryption.
+    pub preserve: Vec<isize>,
+    /// The list of indices of characters to be masked while performing masked decryption.
+    pub mask: Option<Vec<isize>>,
+    /// Whether encrypted/decrypted data should satisfy LUHN checksum formula.
+    pub luhn_check: Option<bool>,
+    /// The user-friendly name for the data type that represents the input data.
+    pub name: Option<String>
+}
+
+/// A structure indicating which indices in an encrypted part to mask or preserve.
+#[derive(Eq, PartialEq, Debug, Serialize, Deserialize, Clone)]
+#[serde(untagged)]
+pub enum FpePreserveMask {
+    /// Indicates that the entire encrypted part is to be preserved or masked.
+    Entire (
+        All
+    ),
+    /// Indicates that only certain characters are to be preserved or masked. Indices are
+    /// Python-like; i.e., negative indices index from the back of the token portion, with
+    /// index -1 being the end of the array. (Indicating that nothing should be preserved
+    /// or masked can be done via an empty list, which is the default value for this enum.)
+    ByChars (
+        Vec<isize>
+    )
+}
+
+/// An index for listing subparts of a compound part to which certain constraints are to be applied.
+/// For Concat parts, this is the zero-based index of the subpart in the `concat` field, and for
+/// Multiple parts, this is always 0 (due to a Multiple having only one subpart).
+pub type FpeSubpartIndex = usize;
+
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+pub struct HistoryItem {
+    pub id: Uuid,
+    pub state: HistoryItemState,
+    pub created_at: Time,
+    pub expiry: Time
+}
+
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+pub struct HistoryItemState {
+    pub activation_date: Option<Time>,
+    #[serde(default)]
+    pub activation_undo_window: Option<Secs>,
+    pub revocation_reason: Option<RevocationReason>,
+    pub compromise_date: Option<Time>,
+    pub deactivation_date: Option<Time>,
+    #[serde(default)]
+    pub deactivation_undo_window: Option<Secs>,
+    pub destruction_date: Option<Time>,
+    pub deletion_date: Option<Time>,
+    pub state: SobjectState,
+    pub key_ops: KeyOperations,
+    pub public_only: bool,
+    pub has_key: bool,
+    pub rotation_policy: Option<RotationPolicy>,
+    #[serde(default)]
+    pub group_id: Option<Uuid>
+}
+
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+pub struct HmacOptions {
+    pub minimum_key_length: Option<u32>
+}
+
+/// Signing keys used to validate signed JWT tokens.
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "lowercase", tag = "kind")]
+pub enum JwtSigningKeys {
+    Stored {
+        /// Mapping key ids to DER-encoded public key.
+        keys: HashMap<String,Blob>
+    },
+    Fetched {
+        url: String,
+        /// Number of seconds that the service is allowed to cache the fetched keys.
+        cache_duration: u64
+    }
+}
+
+#[derive(Copy, PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+pub struct KeyHistoryPolicy {
+    pub undo_time_window: Secs
+}
+
+/// Linked security objects.
+#[derive(PartialEq, Eq, Debug, Default, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct KeyLinks {
+    #[serde(default)]
+    pub replacement: Option<Uuid>,
+    #[serde(default)]
+    pub replaced: Option<Uuid>,
+    #[serde(default)]
+    pub copied_from: Option<Uuid>,
+    #[serde(default)]
+    pub copied_to: Option<Vec<Uuid>>,
+    #[serde(default)]
+    pub subkeys: Vec<Uuid>,
+    #[serde(default)]
+    pub parent: Option<Uuid>
+}
+
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
+pub struct KeyMetadataPolicy {
+    /// Applies to all objects.
+    pub base: MetadataPolicyItem,
+    /// Each entry in this map fully overrides `base` for a particular object type.
+    pub for_obj_type: HashMap<ObjectType,MetadataPolicyItem>,
+    /// What to do with legacy objects that are not compliant with this policy.
+    /// Note that objects are not allowed to be created/updated if the result is
+    /// not compliant with the policy. Non-compliant legacy objects can only be
+    /// updated to comply with the policy (e.g. by adding missing required metadata).
+    pub legacy_objects: LegacyKeyPolicy
+}
 
 /// Operations allowed to be performed on a given key.
 pub use self::key_operations::KeyOperations;
 pub mod key_operations {
-    bitflags_set! {
+    bitflags_set!{
         pub struct KeyOperations: u64 {
             const SIGN = 0x0000000000000001;
             const VERIFY = 0x0000000000000002;
@@ -29,90 +804,142 @@ pub mod key_operations {
     }
 }
 
-/// Type of security object.
-#[derive(Debug, Eq, PartialEq, Copy, Hash, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "UPPERCASE")]
-pub enum ObjectType {
-    Aes,
-    Des,
-    Des3,
-    Rsa,
-    Ec,
-    Opaque,
-    Hmac,
-    Secret,
-    Certificate,
-}
-
-/// The origin of a security object - where it was created / generated.
-#[derive(Copy, PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
-pub enum ObjectOrigin {
-    FortanixHSM,
-    Transient,
-    External,
-}
-
-/// Identifies a standardized elliptic curve.
-#[derive(Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
-pub enum EllipticCurve {
-    X25519,
-    Ed25519,
-    X448,
-    SecP192K1,
-    SecP224K1,
-    SecP256K1,
-    NistP192,
-    NistP224,
-    NistP256,
-    NistP384,
-    NistP521,
-    Gost256A,
-}
-
-/// Linked security objects.
-#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct KeyLinks {
+#[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize, Clone)]
+pub struct KmipClientConfig {
     #[serde(default)]
-    pub replacement: Option<Uuid>,
-    #[serde(default)]
-    pub replaced: Option<Uuid>,
+    pub ignore_unknown_key_ops_for_secrets: Option<bool>
 }
 
-/// A security principal.
+/// LDAP authorization settings.
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "lowercase")]
-pub enum Principal {
-    App(Uuid),
-    User(Uuid),
-    Plugin(Uuid),
-    /// UserViaApp signifies a user authorizing some app to act on its behalf through OAuth.
-    UserViaApp {
-        user_id: Uuid,
-        scopes: HashSet<OauthScope>,
+pub struct LdapAuthorizationConfig {
+    /// Number of seconds after which the authorization should be checked again.
+    pub valid_for: u64,
+    /// A map from account roles to distinguished names of LDAP groups.
+    /// If a DN is specified for an account role, entities with that role
+    /// must be a member of the specified LDAP group.
+    pub require_role: HashMap<AccountRole,String>
+}
+
+/// Distinguished Name (DN) resolution method. Given a user's email address, a DN resolution method
+/// is used to find the user's DN in an LDAP directory.
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "kebab-case", tag = "method")]
+pub enum LdapDnResolution {
+    /// Transform the user email through a pattern to derive the DN.
+    Construct {
+        /// For example: "example.com" => "uid={},ou=users,dc=example,dc=com".
+        domain_format: HashMap<String,String>
     },
+    /// Search the directory using the LDAP `mail` attribute matching user's email.
+    SearchByMail,
+    /// Use email in place of DN. This method works with Active Directory if the userPrincipalName
+    /// attribute is set for the user. https://docs.microsoft.com/en-us/windows/desktop/ad/naming-properties
+    #[serde(rename = "upn")]
+    UserPrincipalName
 }
 
-/// A hash algorithm.
-#[derive(Debug, Eq, PartialEq, Copy, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "UPPERCASE")]
-pub enum DigestAlgorithm {
-    Blake2b256,
-    Blake2b384,
-    Blake2b512,
-    Blake2s256,
-    Ripemd160,
-    Ssl3,
-    Sha1,
-    Sha256,
-    Sha384,
-    Sha512,
-    Streebog256,
-    Streebog512,
-    Sha3_224,
-    Sha3_256,
-    Sha3_384,
-    Sha3_512,
+/// Credentials used by the service to authenticate itself to an LDAP server.
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+pub struct LdapServiceAccount {
+    pub dn: String,
+    pub password: String
+}
+
+#[derive(Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum LegacyKeyPolicy {
+    /// The key can be used for all purposes.
+    Allowed,
+    /// The key cannot be used for any crypto operations until it becomes compliant.
+    Prohibited,
+    /// The key can only be used for these crypto operations:
+    /// - DECRYPT
+    /// - VERIFY
+    /// - MACVERIFY
+    /// - UNWRAPKEY
+    UnprotectOnly
+}
+
+/// LMS specific options
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+pub struct LmsOptions {
+    /// The height of the top level tree
+    pub l1_height: u32,
+    /// The height of the secondary tree
+    pub l2_height: u32,
+    /// The hash function to use
+    pub digest: Option<DigestAlgorithm>
+}
+
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum MetadataDurationConstraint {
+    Forbidden {
+
+    },
+    Required {
+        /// If specified, the value (typically a date) is restricted to be in a
+        /// range expressed in terms of duration with respect to some known point
+        /// in time. For example, if we specify min = 30 days and max = 180 days
+        /// for `deactivation_date`, then the user must specify a deactivation date
+        /// that is within 30 and 180 days of security object's creation time.
+        #[serde(default)]
+        allowed_values: RestrictedDuration
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Default, Serialize, Deserialize, Clone)]
+pub struct MetadataPolicyItem {
+    pub custom_metadata: HashMap<String,MetadataStringConstraint>,
+    pub description: Option<MetadataStringConstraint>,
+    /// If a restricted duration is specified, it is enforced w.r.t object creation time.
+    pub deactivation_date: Option<MetadataDurationConstraint>,
+    /// If a restricted duration is specified, it is enforced w.r.t object creation time.
+    /// NOTE: Specifying a minimum duration for this field may not be a good
+    /// idea since it would not be possible to create a key and start using it
+    /// immediately in the affected group(s).
+    pub activation_date: Option<MetadataDurationConstraint>
+}
+
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum MetadataStringConstraint {
+    Forbidden {
+
+    },
+    Required {
+        /// If set to `true`, the value must have a length > 0 after trimming
+        /// leading and trailing whitespace characters.
+        non_empty_after_trim: bool,
+        /// If not specified or empty, it will not impose any restrictions on the value.
+        allowed_values: HashSet<String>
+    }
+}
+
+/// A challenge used for multi-factor authentication.
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
+pub struct MfaChallengeResponse {
+    pub u2f_challenge: String,
+    pub u2f_keys: Vec<U2fRegisteredKey>
+}
+
+/// Specifies the Mask Generating Function (MGF) to use.
+#[derive(Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum Mgf {
+    Mgf1 {
+        hash: DigestAlgorithm
+    }
+}
+
+/// MGF policy.
+#[derive(Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum MgfPolicy {
+    Mgf1 {
+        hash: Option<DigestAlgorithm>
+    }
 }
 
 /// OAuth scope.
@@ -120,66 +947,209 @@ pub enum DigestAlgorithm {
 #[serde(rename_all = "lowercase")]
 pub enum OauthScope {
     App,
+    OpenID,
+    Email,
+    Profile
 }
 
-singleton_backcompat! {
-    /// User's role in a group.
-    #[derive(Debug, Eq, PartialEq, Copy, Clone)]
-    #[serde(rename_all = "UPPERCASE")]
-    pub enum UserGroupRole {
-        GroupAuditor,
-        GroupAdministrator
+/// The origin of a security object - where it was created / generated.
+#[derive(Copy, PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+pub enum ObjectOrigin {
+    FortanixHSM,
+    Transient,
+    External
+}
+
+/// Type of security object.
+#[derive(Debug, Eq, PartialEq, Copy, Hash, EnumIter, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum ObjectType {
+    Aes,
+    Des,
+    Des3,
+    Rsa,
+    Dsa,
+    Ec,
+    Opaque,
+    Hmac,
+    LedaBeta,
+    Round5Beta,
+    Secret,
+    Seed,
+    Lms,
+    Certificate,
+    Pbe
+}
+
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+pub struct OpaqueOptions {
+
+}
+
+#[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize, Clone)]
+pub struct Pkcs11ClientConfig {
+    #[serde(default)]
+    pub fake_rsa_x9_31_keygen_support: Option<bool>,
+    #[serde(default)]
+    pub signing_aes_key_as_hmac: Option<bool>,
+    #[serde(default)]
+    pub exact_key_ops: Option<bool>,
+    #[serde(default)]
+    pub prevent_duplicate_opaque_objects: Option<bool>,
+    #[serde(default)]
+    pub opaque_objects_are_not_certificates: Option<bool>,
+    #[serde(default)]
+    pub max_concurrent_requests_per_slot: Option<usize>
+}
+
+#[derive(Debug, Eq, PartialEq, Copy, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum Pkcs8Mode {
+    PbeWithSHAAnd128BitRC4,
+    PbeWithSHAAnd3KeyTripleDesCbc,
+    PbeWithSHAAnd2KeyTripleDesCbc,
+    Pbes2WithPBKDF2AndKeyDes,
+    Pbes2WithPBKDF2AndKeyTripleDes
+}
+
+/// A security principal.
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "lowercase")]
+pub enum Principal {
+    App (
+        Uuid
+    ),
+    User (
+        Uuid
+    ),
+    Plugin (
+        Uuid
+    ),
+    /// UserViaApp signifies a user authorizing some app to act on its behalf through OAuth.
+    UserViaApp {
+        user_id: Uuid,
+        scopes: HashSet<OauthScope>
     }
 }
 
-/// Signing keys used to validate signed JWT tokens.
+/// If enabled, the public key will be available publicly (without authentication) through the GetPublicKey API.
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "lowercase", tag = "kind")]
-pub enum JwtSigningKeys {
-    Stored {
-        /// Mapping key ids to DER-encoded public key.
-        keys: HashMap<String, Blob>,
+#[serde(rename_all = "snake_case", tag = "state")]
+pub enum PublishPublicKeyConfig {
+    Enabled {
+        /// Additionally list the previous version of the key if not compromised.
+        list_previous_version: bool
     },
-    Fetched {
-        url: String,
-        /// Number of seconds that the service is allowed to cache the fetched keys.
-        cache_duration: u64,
-    },
+    Disabled
 }
 
-/// Constraints on RSA encryption parameters. In general, if a constraint is not specified, anything is allowed.
+/// Quorum approval policy.
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
+pub struct Quorum {
+    pub n: usize,
+    pub members: Vec<QuorumPolicy>,
+    #[serde(flatten)]
+    pub config: ApprovalAuthConfig
+}
+
+/// Approval policy.
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
+pub struct QuorumPolicy {
+    #[serde(default)]
+    pub quorum: Option<Quorum>,
+    #[serde(default)]
+    pub user: Option<Uuid>,
+    #[serde(default)]
+    pub app: Option<Uuid>
+}
+
+#[derive(Debug, PartialEq, Eq, Default, Serialize, Deserialize, Clone)]
+pub struct RestrictedDuration {
+    pub min: Option<TimeSpan>,
+    pub max: Option<TimeSpan>
+}
+
+/// Reason for revoking a key.
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
+pub struct RevocationReason {
+    pub code: RevocationReasonCode,
+    /// Message is used exclusively for audit trail/logging purposes and MAY contain additional
+    /// information about why the object was revoked.
+    pub message: Option<String>,
+    pub compromise_occurance_date: Option<Time>
+}
+
+/// Reasons to revoke a security object.
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
+pub enum RevocationReasonCode {
+    Unspecified,
+    KeyCompromise,
+    CACompromise,
+    AffiliationChanged,
+    Superseded,
+    CessationOfOperation,
+    PrivilegeWithdrawn
+}
+
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum RotationInterval {
+    IntervalDays (
+        u32
+    ),
+    IntervalMonths (
+        u32
+    )
+}
+
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+pub struct RotationPolicy {
+    #[serde(flatten)]
+    pub interval: Option<RotationInterval>,
+    #[serde(default)]
+    pub effective_at: Option<Time>,
+    pub deactivate_rotated_key: bool
+}
+
+/// Type of padding to use for RSA encryption. The use of PKCS#1 v1.5 padding is strongly
+/// discouraged, because of its susceptibility to Bleichenbacher's attack. The padding specified
+/// must adhere to the key's encryption policy. If not specified, the default based on the key's
+/// policy will be used.
 #[derive(Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
-pub struct RsaEncryptionPolicy {
-    pub padding: Option<RsaEncryptionPaddingPolicy>,
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum RsaEncryptionPadding {
+    /// Optimal Asymmetric Encryption Padding (PKCS#1 v2.1).
+    Oaep {
+        mgf: Mgf
+    },
+    /// PKCS#1 v1.5 padding.
+    Pkcs1V15 {
+
+    },
+    RawDecrypt {
+
+    }
 }
 
 /// RSA encryption padding policy.
 #[derive(Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum RsaEncryptionPaddingPolicy {
-    Oaep { mgf: Option<MgfPolicy> },
-    Pkcs1V15 {},
+    Oaep {
+        mgf: Option<MgfPolicy>
+    },
+    Pkcs1V15 {
+
+    },
+    RawDecrypt {
+
+    }
 }
 
-/// Constraints on RSA signature parameters. In general, if a constraint is not specified, anything is allowed.
+/// Constraints on RSA encryption parameters. In general, if a constraint is not specified, anything is allowed.
 #[derive(Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
-pub struct RsaSignaturePolicy {
-    pub padding: Option<RsaSignaturePaddingPolicy>,
-}
-
-/// RSA signature padding policy.
-#[derive(Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-pub enum RsaSignaturePaddingPolicy {
-    Pss { mgf: Option<MgfPolicy> },
-    Pkcs1V15 {},
-}
-
-/// MGF policy.
-#[derive(Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "snake_case")]
-pub enum MgfPolicy {
-    Mgf1 { hash: Option<DigestAlgorithm> },
+pub struct RsaEncryptionPolicy {
+    pub padding: Option<RsaEncryptionPaddingPolicy>
 }
 
 /// RSA-specific options.
@@ -205,139 +1175,54 @@ pub struct RsaOptions {
     /// policy. The default for new keys is `[{}]` (no constraints).
     /// If (part of) a constraint is not specified, anything is allowed for that constraint.
     pub signature_policy: Vec<RsaSignaturePolicy>,
-}
-
-/// FPE-specific options.
-#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
-pub struct FpeOptions {
-    /// The base for input data.
-    pub radix: u32,
-    /// The minimum allowed length for the input data.
-    pub min_length: u32,
-    /// The maximum allowed length for the input data.
-    pub max_length: u32,
-    /// The list of indices of characters to be preserved while performing encryption/decryption.
-    pub preserve: Vec<isize>,
-    /// The list of indices of characters to be masked while performing masked decryption.
-    pub mask: Option<Vec<isize>>,
-    /// Whether encrypted/decrypted data should satisfy LUHN checksum formula.
-    pub luhn_check: Option<bool>,
-    /// The user-friendly name for the data type that represents the input data.
-    pub name: Option<String>,
-}
-
-/// Approval policy.
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
-pub struct ApprovalPolicy {
     #[serde(default)]
-    pub quorum: Option<ApprovalPolicyQuorum>,
-    #[serde(default)]
-    pub user: Option<Uuid>,
-    #[serde(default)]
-    pub app: Option<Uuid>,
+    pub minimum_key_length: Option<u32>
 }
 
-/// Quorum approval policy.
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
-pub struct ApprovalPolicyQuorum {
-    pub n: usize,
-    pub members: Vec<ApprovalPolicy>,
-    #[serde(flatten)]
-    pub config: ApprovalAuthConfig,
-}
-
-/// Authentication requirements for approval request reviewers.
-#[derive(Copy, PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
-pub struct ApprovalAuthConfig {
-    pub require_password: bool,
-    pub require_2fa: bool,
-}
-
-/// Reason for revoking a key.
-#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
-pub struct RevocationReason {
-    pub code: RevocationReasonCode,
-    /// Message is used exclusively for audit trail/logging purposes and MAY contain additional
-    /// information about why the object was revoked.
-    pub message: Option<String>,
-    pub compromise_occurance_date: Option<Time>,
-}
-
-/// Reasons to revoke a security object.
-#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
-pub enum RevocationReasonCode {
-    Unspecified,
-    KeyCompromise,
-    CACompromise,
-    AffiliationChanged,
-    Superseded,
-    CessationOfOperation,
-    PrivilegeWithdrawn,
-}
-
-/// If enabled, the public key will be available publicly (without authentication) through the GetPublicKey API.
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "snake_case", tag = "state")]
-pub enum PublishPublicKeyConfig {
-    Enabled {
-        /// Additionally list the previous version of the key if not compromised.
-        list_previous_version: bool,
+/// Type of padding to use for RSA signatures. The padding specified must adhere to the key's
+/// signature policy. If not specified, the default based on the key's policy will be used.
+#[derive(Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum RsaSignaturePadding {
+    /// Probabilistic Signature Scheme (PKCS#1 v2.1).
+    Pss {
+        mgf: Mgf
     },
-    Disabled,
+    /// PKCS#1 v1.5 padding.
+    Pkcs1V15 {
+
+    }
 }
 
-#[derive(Eq, PartialEq, Debug, Serialize, Deserialize, Clone)]
-pub struct Sobject {
-    pub acct_id: Uuid,
-    #[serde(default)]
-    pub activation_date: Option<Time>,
-    #[serde(default)]
-    pub compromise_date: Option<Time>,
-    pub created_at: Time,
-    pub creator: Principal,
-    #[serde(default)]
-    pub custom_metadata: Option<HashMap<String, String>>,
-    #[serde(default)]
-    pub deactivation_date: Option<Time>,
-    #[serde(default)]
-    pub description: Option<String>,
-    #[serde(default)]
-    pub deterministic_signatures: Option<bool>,
-    #[serde(default)]
-    pub elliptic_curve: Option<EllipticCurve>,
-    pub enabled: bool,
-    #[serde(default)]
-    pub fpe: Option<FpeOptions>,
-    pub key_ops: KeyOperations,
-    #[serde(default)]
-    pub key_size: Option<u32>,
-    #[serde(default)]
-    pub kid: Option<Uuid>,
-    pub lastused_at: Time,
-    #[serde(default)]
-    pub links: Option<KeyLinks>,
-    #[serde(default)]
-    pub name: Option<String>,
-    pub never_exportable: Option<bool>,
-    pub obj_type: ObjectType,
-    pub origin: ObjectOrigin,
-    #[serde(default)]
-    pub pub_key: Option<Blob>,
-    pub public_only: bool,
-    #[serde(default)]
-    pub publish_public_key: Option<PublishPublicKeyConfig>,
-    #[serde(default)]
-    pub revocation_reason: Option<RevocationReason>,
-    #[serde(default)]
-    pub rsa: Option<RsaOptions>,
-    #[serde(default)]
-    pub state: Option<SobjectState>,
-    #[serde(default)]
-    pub transient_key: Option<Blob>,
-    #[serde(default)]
-    pub value: Option<Blob>,
-    #[serde(default)]
-    pub group_id: Option<Uuid>,
+/// RSA signature padding policy.
+#[derive(Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum RsaSignaturePaddingPolicy {
+    Pss {
+        mgf: Option<MgfPolicy>
+    },
+    Pkcs1V15 {
+
+    }
+}
+
+/// Constraints on RSA signature parameters. In general, if a constraint is not specified, anything is allowed.
+#[derive(Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
+pub struct RsaSignaturePolicy {
+    pub padding: Option<RsaSignaturePaddingPolicy>
+}
+
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+pub struct SecretOptions {
+
+}
+
+pub type Secs = u64;
+
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+pub struct SeedOptions {
+    pub cipher_mode: Option<CipherMode>,
+    pub random_iv: Option<bool>
 }
 
 /// A request to sign data (or hash value) using an asymmetric key.
@@ -352,7 +1237,7 @@ pub struct SignRequest {
     /// To reduce request size and avoid reaching the request size limit, prefer `hash`.
     pub data: Option<Blob>,
     pub mode: Option<SignatureMode>,
-    pub deterministic_signature: Option<bool>,
+    pub deterministic_signature: Option<bool>
 }
 
 /// Result of sign operation.
@@ -361,7 +1246,185 @@ pub struct SignResponse {
     /// Key id is returned for non-transient keys.
     #[serde(default)]
     pub kid: Option<Uuid>,
-    pub signature: Blob,
+    pub signature: Blob
+}
+
+/// Signature mode.
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
+#[serde(untagged)]
+pub enum SignatureMode {
+    Rsa (
+        RsaSignaturePadding
+    )
+}
+
+#[derive(Eq, PartialEq, Debug, Serialize, Deserialize, Clone)]
+pub struct Sobject {
+    pub acct_id: Uuid,
+    #[serde(default)]
+    pub activation_date: Option<Time>,
+    #[serde(default)]
+    pub aes: Option<AesOptions>,
+    #[serde(default)]
+    pub compliant_with_policies: Option<bool>,
+    #[serde(default)]
+    pub compromise_date: Option<Time>,
+    pub created_at: Time,
+    pub creator: Principal,
+    #[serde(default)]
+    pub custom_metadata: Option<HashMap<String,String>>,
+    #[serde(default)]
+    pub deactivation_date: Option<Time>,
+    #[serde(default)]
+    pub deletion_date: Option<Time>,
+    #[serde(default)]
+    pub des: Option<DesOptions>,
+    #[serde(default)]
+    pub des3: Option<Des3Options>,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub destruction_date: Option<Time>,
+    #[serde(default)]
+    pub deterministic_signatures: Option<bool>,
+    #[serde(default)]
+    pub dsa: Option<DsaOptions>,
+    #[serde(default)]
+    pub elliptic_curve: Option<EllipticCurve>,
+    pub enabled: bool,
+    #[serde(default)]
+    pub external: Option<ExternalSobjectInfo>,
+    #[serde(default)]
+    pub fpe: Option<FpeOptions>,
+    #[serde(default)]
+    pub history: Option<Vec<HistoryItem>>,
+    #[serde(default)]
+    pub kcv: Option<String>,
+    pub key_ops: KeyOperations,
+    #[serde(default)]
+    pub key_size: Option<u32>,
+    #[serde(default)]
+    pub kid: Option<Uuid>,
+    pub lastused_at: Time,
+    #[serde(default)]
+    pub links: Option<KeyLinks>,
+    #[serde(default)]
+    pub lms: Option<LmsOptions>,
+    #[serde(default)]
+    pub name: Option<String>,
+    pub never_exportable: Option<bool>,
+    pub obj_type: ObjectType,
+    pub origin: ObjectOrigin,
+    #[serde(default)]
+    pub pub_key: Option<Blob>,
+    pub public_only: bool,
+    #[serde(default)]
+    pub publish_public_key: Option<PublishPublicKeyConfig>,
+    #[serde(default)]
+    pub revocation_reason: Option<RevocationReason>,
+    #[serde(default)]
+    pub rotation_policy: Option<RotationPolicy>,
+    #[serde(default)]
+    pub rsa: Option<RsaOptions>,
+    #[serde(default)]
+    pub scheduled_rotation: Option<Time>,
+    #[serde(default)]
+    pub seed: Option<SeedOptions>,
+    #[serde(default)]
+    pub state: Option<SobjectState>,
+    #[serde(default)]
+    pub transient_key: Option<Blob>,
+    #[serde(default)]
+    pub value: Option<Blob>,
+    #[serde(default)]
+    pub group_id: Option<Uuid>
+}
+
+/// Uniquely identifies a persisted or transient sobject.
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum SobjectDescriptor {
+    Kid (
+        Uuid
+    ),
+    Name (
+        String
+    ),
+    TransientKey (
+        Blob
+    ),
+    Inline {
+        value: Blob,
+        obj_type: ObjectType
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Copy, Serialize, Deserialize, Clone)]
+pub enum SobjectState {
+    PreActive,
+    Active,
+    Deactivated,
+    Compromised,
+    Destroyed,
+    Deleted
+}
+
+#[derive(Debug, Copy, PartialEq, Eq, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum TimeSpan {
+    Seconds (
+        u32
+    ),
+    Minutes (
+        u32
+    ),
+    Hours (
+        u32
+    ),
+    Days (
+        u32
+    )
+}
+
+/// TLS settings.
+#[derive(PartialEq, Eq, Hash, Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "snake_case", tag = "mode")]
+pub enum TlsConfig {
+    Disabled,
+    Opportunistic,
+    Required {
+        validate_hostname: bool,
+        ca: CaConfig,
+        client_key: Option<Blob>,
+        client_cert: Option<Blob>
+    }
+}
+
+/// Request for second factor authentication with a U2f device.
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct U2fAuthRequest {
+    pub key_handle: Blob,
+    pub signature_data: Blob,
+    pub client_data: Blob
+}
+
+/// Description of a registered U2F device.
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct U2fRegisteredKey {
+    pub key_handle: String,
+    pub version: String
+}
+
+singleton_backcompat!{
+    /// User's role in a group.
+    #[derive(Debug, Eq, PartialEq, Copy, Clone)]
+    #[serde(rename_all = "UPPERCASE")]
+    pub enum UserGroupRole {
+        GroupAuditor,
+        GroupAdministrator
+    }
 }
 
 /// Request to verify a signature using an asymmetric key.
@@ -379,7 +1442,7 @@ pub struct VerifyRequest {
     pub data: Option<Blob>,
     pub mode: Option<SignatureMode>,
     /// The signature to verify.
-    pub signature: Blob,
+    pub signature: Blob
 }
 
 /// Result of verifying a signature or MAC.
@@ -389,56 +1452,6 @@ pub struct VerifyResponse {
     #[serde(default)]
     pub kid: Option<Uuid>,
     /// True if the signature verified and false if it did not.
-    pub result: bool,
+    pub result: bool
 }
 
-/// Specifies the Mask Generating Function (MGF) to use.
-#[derive(Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "snake_case")]
-pub enum Mgf {
-    Mgf1 { hash: DigestAlgorithm },
-}
-
-/// Signature mode.
-#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
-#[serde(untagged)]
-pub enum SignatureMode {
-    Rsa(RsaSignaturePadding),
-}
-
-/// Type of padding to use for RSA signatures. The padding specified must adhere to the key's
-/// signature policy. If not specified, the default based on the key's policy will be used.
-#[derive(Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-pub enum RsaSignaturePadding {
-    /// Probabilistic Signature Scheme (PKCS#1 v2.1).
-    Pss { mgf: Mgf },
-    /// PKCS#1 v1.5 padding.
-    Pkcs1V15 {},
-}
-
-/// Uniquely identifies a persisted or transient sobject.
-#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "snake_case")]
-pub enum SobjectDescriptor {
-    Kid(Uuid),
-    Name(String),
-    TransientKey(Blob),
-}
-
-/// Request for second factor authentication with a U2f device.
-#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct U2fAuthRequest {
-    pub key_handle: Blob,
-    pub signature_data: Blob,
-    pub client_data: Blob,
-}
-
-#[derive(Debug, Eq, PartialEq, Copy, Serialize, Deserialize, Clone)]
-pub enum SobjectState {
-    PreActive,
-    Active,
-    Deactivated,
-    Compromised,
-}

--- a/src/generated/common_generated.rs
+++ b/src/generated/common_generated.rs
@@ -697,6 +697,28 @@ pub enum FpePreserveMask {
 /// Multiple parts, this is always 0 (due to a Multiple having only one subpart).
 pub type FpeSubpartIndex = usize;
 
+/// An access reason provided by Google when making EKMS API calls.
+#[derive(Debug, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum GoogleAccessReason {
+    ReasonUnspecified = 0,
+    CustomerInitiatedSupport = 1,
+    GoogleInitiatedService = 2,
+    ThirdPartyDataRequest = 3,
+    GoogleInitiatedReview = 4,
+    CustomerInitiatedAccess = 5,
+    GoogleInitiatedSystemOperation = 6,
+    ReasonNotExpected = 7,
+    ModifiedCustomerInitiatedAccess = 8
+}
+
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "snake_case")]
+pub struct GoogleAccessReasonPolicy {
+    pub allow: HashSet<GoogleAccessReason>,
+    pub allow_missing_reason: bool
+}
+
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
 pub struct HistoryItem {
     pub id: Uuid,
@@ -787,18 +809,44 @@ pub use self::key_operations::KeyOperations;
 pub mod key_operations {
     bitflags_set!{
         pub struct KeyOperations: u64 {
+            // If this is set, the key can be used to for signing.
             const SIGN = 0x0000000000000001;
+            //  If this is set, the key can used for verifying a signature.
             const VERIFY = 0x0000000000000002;
+            //  If this is set, the key can be used for encryption.
             const ENCRYPT = 0x0000000000000004;
+            //  If this is set, the key can be used for decryption.
             const DECRYPT = 0x0000000000000008;
+            //  If this is set, the key can be used wrapping other keys.
+            //  The key being wrapped must have the EXPORT operation enabled.
             const WRAPKEY = 0x0000000000000010;
+            //  If this is set, the key can be used to unwrap a wrapped key.
             const UNWRAPKEY = 0x0000000000000020;
+            //  If this is set, the key can be used to derive another key.
             const DERIVEKEY = 0x0000000000000040;
+            //  If this is set, the key can be used to compute a cryptographic
+            //  Message Authentication Code (MAC) on a message.
             const MACGENERATE = 0x0000000000000080;
+            //  If they is set, the key can be used to verify a MAC.
             const MACVERIFY = 0x0000000000000100;
+            //  If this is set, the value of the key can be retrieved
+            //  with an authenticated request. This shouldn't be set unless
+            //  required. It is more secure to keep the key's value inside DSM only.
             const EXPORT = 0x0000000000000200;
+            //  Without this operation, management operations like delete, destroy,
+            //  rotate, activate, restore, revoke, revert, update, remove_private, etc.
+            //  cannot be performed by a crypto App.
+            //  A user with access or admin app can still perform these operations.
+            //  This option is only relevant for crypto apps.
             const APPMANAGEABLE = 0x0000000000000400;
+            //  If this is set, audit logs will not be recorded for the key.
+            //   High volume here tries to signify a key that is being used a lot
+            //   and will produce lots of logs. Setting this operation disables
+            //   audit logs for the key.
             const HIGHVOLUME = 0x0000000000000800;
+            //  If this is set, the key can be used for key agreement.
+            //  Both the private and public key should have this option enabled
+            //  to perform an agree operation.
             const AGREEKEY = 0x0000000000001000;
         }
     }
@@ -1296,6 +1344,10 @@ pub struct Sobject {
     pub external: Option<ExternalSobjectInfo>,
     #[serde(default)]
     pub fpe: Option<FpeOptions>,
+    /// Key Access Justifications for GCP EKM.
+    /// For more details: https://cloud.google.com/cloud-provider-access-management/key-access-justifications/docs/overview
+    #[serde(default)]
+    pub google_access_reason_policy: Option<GoogleAccessReasonPolicy>,
     #[serde(default)]
     pub history: Option<Vec<HistoryItem>>,
     #[serde(default)]

--- a/src/generated/crypto_generated.rs
+++ b/src/generated/crypto_generated.rs
@@ -10,7 +10,7 @@ use super::*;
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum AgreeKeyMechanism {
-    DiffieHellman
+    DiffieHellman,
 }
 
 /// Request to perform key agreement.
@@ -41,7 +41,7 @@ pub struct AgreeKeyRequest {
     pub description: Option<String>,
     /// User-defined metadata for this key stored as key-value pairs.
     #[serde(default)]
-    pub custom_metadata: Option<HashMap<String,String>>,
+    pub custom_metadata: Option<HashMap<String, String>>,
     /// Optional array of key operations to be enabled for this security object. If not
     /// provided the service will provide a default set of key operations. Note that if you
     /// provide an empty array, all key operations will be disabled.
@@ -50,7 +50,7 @@ pub struct AgreeKeyRequest {
     #[serde(default)]
     pub state: Option<SobjectState>,
     /// If set to true, the resulting key will be transient.
-    pub transient: bool
+    pub transient: bool,
 }
 
 /// Finalize a multi-part decryption.
@@ -61,13 +61,13 @@ pub struct DecryptFinalRequest {
     pub state: Blob,
     /// Tag is only applicable when using GCM mode.
     #[serde(default)]
-    pub tag: Option<Blob>
+    pub tag: Option<Blob>,
 }
 
 /// Final result of a multi-part decryption.
 #[derive(Default, Debug, Serialize, Deserialize, Clone)]
 pub struct DecryptFinalResponse {
-    pub plain: Blob
+    pub plain: Blob,
 }
 
 /// Initialize multi-part decryption.
@@ -85,7 +85,7 @@ pub struct DecryptInitRequest {
     pub iv: Option<Blob>,
     /// Authenticated data is only applicable when using GCM mode.
     #[serde(default)]
-    pub ad: Option<Blob>
+    pub ad: Option<Blob>,
 }
 
 /// Result of initializing multi-part decryption.
@@ -95,7 +95,7 @@ pub struct DecryptInitResponse {
     #[serde(default)]
     pub kid: Option<Uuid>,
     /// Opaque data, not to be interpreted or modified by the client and must be provided with next request.
-    pub state: Blob
+    pub state: Blob,
 }
 
 /// A request to decrypt data using a symmetric or asymmetric key.
@@ -123,7 +123,7 @@ pub struct DecryptRequest {
     /// this flag.
     /// With `MASKDECRYPT` permission, this flag is ignored.
     #[serde(default)]
-    pub masked: Option<bool>
+    pub masked: Option<bool>,
 }
 
 /// Result of a decryption.
@@ -132,7 +132,7 @@ pub struct DecryptResponse {
     /// The key id of the key used to decrypt. Returned for non-transient keys.
     #[serde(default)]
     pub kid: Option<Uuid>,
-    pub plain: Blob
+    pub plain: Blob,
 }
 
 /// Multi-part decryption request.
@@ -141,7 +141,7 @@ pub struct DecryptUpdateRequest {
     #[serde(default)]
     pub key: Option<SobjectDescriptor>,
     pub cipher: Blob,
-    pub state: Blob
+    pub state: Blob,
 }
 
 /// Result of multi-part decryption.
@@ -149,7 +149,7 @@ pub struct DecryptUpdateRequest {
 pub struct DecryptUpdateResponse {
     pub plain: Blob,
     /// Opaque data, not to be interpreted or modified by the client and must be provided with next request.
-    pub state: Blob
+    pub state: Blob,
 }
 
 /// Encodes the mechanism to be used when deriving a new key from an existing key.
@@ -158,9 +158,7 @@ pub struct DecryptUpdateResponse {
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum DeriveKeyMechanism {
-    EncryptData (
-        EncryptRequest
-    )
+    EncryptData(EncryptRequest),
 }
 
 /// Request to derive a key.
@@ -192,7 +190,7 @@ pub struct DeriveKeyRequest {
     pub description: Option<String>,
     /// User-defined metadata for this key stored as key-value pairs.
     #[serde(default)]
-    pub custom_metadata: Option<HashMap<String,String>>,
+    pub custom_metadata: Option<HashMap<String, String>>,
     /// Optional array of key operations to be enabled for this security object. If not
     /// provided the service will provide a default set of key operations. Note that if you
     /// provide an empty array, all key operations will be disabled.
@@ -202,20 +200,20 @@ pub struct DeriveKeyRequest {
     pub state: Option<SobjectState>,
     /// If set to true, the derived key will be transient.
     #[serde(default)]
-    pub transient: Option<bool>
+    pub transient: Option<bool>,
 }
 
 /// Request to compute the hash of arbitrary data.
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
 pub struct DigestRequest {
     pub alg: DigestAlgorithm,
-    pub data: Blob
+    pub data: Blob,
 }
 
 /// Result of a hash operation.
 #[derive(Default, Debug, Serialize, Deserialize, Clone)]
 pub struct DigestResponse {
-    pub digest: Blob
+    pub digest: Blob,
 }
 
 /// Finalize a multi-part encryption.
@@ -226,7 +224,7 @@ pub struct EncryptFinalRequest {
     pub state: Blob,
     /// Tag length is only applicable when using GCM mode.
     #[serde(default)]
-    pub tag_len: Option<usize>
+    pub tag_len: Option<usize>,
 }
 
 /// Final result of a multi-part encryption.
@@ -235,7 +233,7 @@ pub struct EncryptFinalResponse {
     pub cipher: Blob,
     /// Tag is only returned for symmetric encryption with GCM mode.
     #[serde(default)]
-    pub tag: Option<Blob>
+    pub tag: Option<Blob>,
 }
 
 /// Initialize multi-part encryption.
@@ -251,7 +249,7 @@ pub struct EncryptInitRequest {
     pub iv: Option<Blob>,
     /// Authenticated data is only applicable when using GCM mode.
     #[serde(default)]
-    pub ad: Option<Blob>
+    pub ad: Option<Blob>,
 }
 
 /// Result of initializing multi-part encryption.
@@ -264,7 +262,7 @@ pub struct EncryptInitResponse {
     #[serde(default)]
     pub iv: Option<Blob>,
     /// Opaque data, not to be interpreted or modified by the client and must be provided with next request.
-    pub state: Blob
+    pub state: Blob,
 }
 
 /// A request to encrypt data using a symmetric or asymmetric key.
@@ -285,7 +283,7 @@ pub struct EncryptRequest {
     pub ad: Option<Blob>,
     /// Tag length is only applicable when using GCM mode.
     #[serde(default)]
-    pub tag_len: Option<usize>
+    pub tag_len: Option<usize>,
 }
 
 /// Result of an encryption.
@@ -300,7 +298,7 @@ pub struct EncryptResponse {
     pub iv: Option<Blob>,
     /// Tag is only returned for symmetric encryption with GCM mode.
     #[serde(default)]
-    pub tag: Option<Blob>
+    pub tag: Option<Blob>,
 }
 
 /// Multi-part encryption request.
@@ -309,7 +307,7 @@ pub struct EncryptUpdateRequest {
     #[serde(default)]
     pub key: Option<SobjectDescriptor>,
     pub plain: Blob,
-    pub state: Blob
+    pub state: Blob,
 }
 
 /// Result of multi-part encryption.
@@ -317,14 +315,14 @@ pub struct EncryptUpdateRequest {
 pub struct EncryptUpdateResponse {
     pub cipher: Blob,
     /// Opaque data, not to be interpreted or modified by the client and must be provided with next request.
-    pub state: Blob
+    pub state: Blob,
 }
 
 /// Key Format
 #[derive(Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
 pub enum KeyFormat {
     Default,
-    Pkcs8
+    Pkcs8,
 }
 
 /// Request for HMAC or CMAC operation.
@@ -334,7 +332,7 @@ pub struct MacRequest {
     pub key: Option<SobjectDescriptor>,
     #[serde(default)]
     pub alg: Option<DigestAlgorithm>,
-    pub data: Blob
+    pub data: Blob,
 }
 
 /// Result of HMAC or CMAC operation.
@@ -346,7 +344,7 @@ pub struct MacResponse {
     #[serde(default)]
     pub digest: Option<Blob>,
     /// The MAC generated for the input data.
-    pub mac: Blob
+    pub mac: Blob,
 }
 
 /// Request to perform key unwrapping.
@@ -386,7 +384,7 @@ pub struct UnwrapKeyRequest {
     pub description: Option<String>,
     /// User-defined metadata for the resulting key stored as key-value pairs.
     #[serde(default)]
-    pub custom_metadata: Option<HashMap<String,String>>,
+    pub custom_metadata: Option<HashMap<String, String>>,
     /// Optional array of key operations to be enabled for the resulting security object. If not
     /// provided the service will provide a default set of key operations. Note that if you provide
     /// an empty array, all key operations will be disabled.
@@ -395,7 +393,7 @@ pub struct UnwrapKeyRequest {
     #[serde(default)]
     pub transient: Option<bool>,
     #[serde(default)]
-    pub kcv: Option<String>
+    pub kcv: Option<String>,
 }
 
 /// Rquest to verify a MAC value.
@@ -412,7 +410,7 @@ pub struct VerifyMacRequest {
     pub digest: Option<Blob>,
     /// Either `digest` or `mac` should be specified.
     #[serde(default)]
-    pub mac: Option<Blob>
+    pub mac: Option<Blob>,
 }
 
 /// Request to perform key wrapping.
@@ -440,7 +438,7 @@ pub struct WrapKeyRequest {
     #[serde(default)]
     pub tag_len: Option<usize>,
     #[serde(default)]
-    pub key_format: Option<KeyFormat>
+    pub key_format: Option<KeyFormat>,
 }
 
 /// Result of key wrapping operation.
@@ -452,7 +450,7 @@ pub struct WrapKeyResponse {
     pub iv: Option<Blob>,
     /// Tag is only returned for symmetric algorithm with GCM mode.
     #[serde(default)]
-    pub tag: Option<Blob>
+    pub tag: Option<Blob>,
 }
 
 pub struct OperationAgree;
@@ -476,8 +474,10 @@ impl SdkmsClient {
         self.execute::<OperationAgree>(req, (), None)
     }
     pub fn request_approval_to_agree(
-        &self, req: &AgreeKeyRequest,
-        description: Option<String>) -> Result<PendingApproval<OperationAgree>> {
+        &self,
+        req: &AgreeKeyRequest,
+        description: Option<String>,
+    ) -> Result<PendingApproval<OperationAgree>> {
         self.request_approval::<OperationAgree>(req, (), None, description)
     }
 }
@@ -525,8 +525,10 @@ impl SdkmsClient {
         self.execute::<OperationDecrypt>(req, (), None)
     }
     pub fn request_approval_to_decrypt(
-        &self, req: &DecryptRequest,
-        description: Option<String>) -> Result<PendingApproval<OperationDecrypt>> {
+        &self,
+        req: &DecryptRequest,
+        description: Option<String>,
+    ) -> Result<PendingApproval<OperationDecrypt>> {
         self.request_approval::<OperationDecrypt>(req, (), None, description)
     }
 }
@@ -618,8 +620,10 @@ impl SdkmsClient {
         self.execute::<OperationDerive>(req, (), None)
     }
     pub fn request_approval_to_derive(
-        &self, req: &DeriveKeyRequest,
-        description: Option<String>) -> Result<PendingApproval<OperationDerive>> {
+        &self,
+        req: &DeriveKeyRequest,
+        description: Option<String>,
+    ) -> Result<PendingApproval<OperationDerive>> {
         self.request_approval::<OperationDerive>(req, (), None, description)
     }
 }
@@ -645,8 +649,10 @@ impl SdkmsClient {
         self.execute::<OperationEncrypt>(req, (), None)
     }
     pub fn request_approval_to_encrypt(
-        &self, req: &EncryptRequest,
-        description: Option<String>) -> Result<PendingApproval<OperationEncrypt>> {
+        &self,
+        req: &EncryptRequest,
+        description: Option<String>,
+    ) -> Result<PendingApproval<OperationEncrypt>> {
         self.request_approval::<OperationEncrypt>(req, (), None, description)
     }
 }
@@ -738,8 +744,10 @@ impl SdkmsClient {
         self.execute::<OperationMac>(req, (), None)
     }
     pub fn request_approval_to_mac(
-        &self, req: &MacRequest,
-        description: Option<String>) -> Result<PendingApproval<OperationMac>> {
+        &self,
+        req: &MacRequest,
+        description: Option<String>,
+    ) -> Result<PendingApproval<OperationMac>> {
         self.request_approval::<OperationMac>(req, (), None, description)
     }
 }
@@ -787,8 +795,10 @@ impl SdkmsClient {
         self.execute::<OperationSign>(req, (), None)
     }
     pub fn request_approval_to_sign(
-        &self, req: &SignRequest,
-        description: Option<String>) -> Result<PendingApproval<OperationSign>> {
+        &self,
+        req: &SignRequest,
+        description: Option<String>,
+    ) -> Result<PendingApproval<OperationSign>> {
         self.request_approval::<OperationSign>(req, (), None, description)
     }
 }
@@ -814,8 +824,10 @@ impl SdkmsClient {
         self.execute::<OperationUnwrap>(req, (), None)
     }
     pub fn request_approval_to_unwrap(
-        &self, req: &UnwrapKeyRequest,
-        description: Option<String>) -> Result<PendingApproval<OperationUnwrap>> {
+        &self,
+        req: &UnwrapKeyRequest,
+        description: Option<String>,
+    ) -> Result<PendingApproval<OperationUnwrap>> {
         self.request_approval::<OperationUnwrap>(req, (), None, description)
     }
 }
@@ -863,9 +875,10 @@ impl SdkmsClient {
         self.execute::<OperationWrap>(req, (), None)
     }
     pub fn request_approval_to_wrap(
-        &self, req: &WrapKeyRequest,
-        description: Option<String>) -> Result<PendingApproval<OperationWrap>> {
+        &self,
+        req: &WrapKeyRequest,
+        description: Option<String>,
+    ) -> Result<PendingApproval<OperationWrap>> {
         self.request_approval::<OperationWrap>(req, (), None, description)
     }
 }
-

--- a/src/generated/crypto_generated.rs
+++ b/src/generated/crypto_generated.rs
@@ -5,128 +5,97 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::*;
-use serde::{Deserialize, Serialize};
 
-/// A cryptographic algorithm.
-#[derive(Debug, Eq, PartialEq, Copy, Hash, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "UPPERCASE")]
-pub enum Algorithm {
-    Aes,
-    Des,
-    Des3,
-    Rsa,
-    Ec,
-    Hmac,
-}
-
-/// Cipher mode used for symmetric key algorithms.
-#[derive(Debug, Eq, PartialEq, Copy, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "UPPERCASE")]
-pub enum CipherMode {
-    Ecb,
-    Cbc,
-    CbcNoPad,
-    Cfb,
-    Ofb,
-    Ctr,
-    Gcm,
-    Ccm,
-    Kw,
-    Kwp,
-    Ff1,
-}
-
-/// A request to encrypt data using a symmetric or asymmetric key.
+/// Mechanism to use for key agreement.
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
-pub struct EncryptRequest {
+#[serde(rename_all = "snake_case")]
+pub enum AgreeKeyMechanism {
+    DiffieHellman
+}
+
+/// Request to perform key agreement.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct AgreeKeyRequest {
+    #[serde(default)]
+    pub activation_date: Option<Time>,
+    #[serde(default)]
+    pub deactivation_date: Option<Time>,
+    pub private_key: SobjectDescriptor,
+    pub public_key: SobjectDescriptor,
+    /// Mechanism to use for key derivation.
+    pub mechanism: AgreeKeyMechanism,
+    /// Name of the agreed-upon key. Key names must be unique within an account.
+    /// The name is ignored for transient keys.
+    pub name: Option<String>,
+    /// Group ID of the security group that this security object should belong to. The user or
+    /// application creating this security object must be a member of this group. If no group is
+    /// specified, the default group for the requesting application will be used.
+    #[serde(default)]
+    pub group_id: Option<Uuid>,
+    /// Type of key to be derived. NB. for security reasons, you shouldn't specify anything but HMAC or Secret.
+    pub key_type: ObjectType,
+    /// Key size in bits. If less than the output size of the algorithm, the secret's most-significant bits will be truncated.
+    pub key_size: u32,
+    pub enabled: bool,
+    #[serde(default)]
+    pub description: Option<String>,
+    /// User-defined metadata for this key stored as key-value pairs.
+    #[serde(default)]
+    pub custom_metadata: Option<HashMap<String,String>>,
+    /// Optional array of key operations to be enabled for this security object. If not
+    /// provided the service will provide a default set of key operations. Note that if you
+    /// provide an empty array, all key operations will be disabled.
+    #[serde(default)]
+    pub key_ops: Option<KeyOperations>,
+    #[serde(default)]
+    pub state: Option<SobjectState>,
+    /// If set to true, the resulting key will be transient.
+    pub transient: bool
+}
+
+/// Finalize a multi-part decryption.
+#[derive(Default, Debug, Serialize, Deserialize, Clone)]
+pub struct DecryptFinalRequest {
     #[serde(default)]
     pub key: Option<SobjectDescriptor>,
-    pub alg: Algorithm,
-    pub plain: Blob,
+    pub state: Blob,
+    /// Tag is only applicable when using GCM mode.
+    #[serde(default)]
+    pub tag: Option<Blob>
+}
+
+/// Final result of a multi-part decryption.
+#[derive(Default, Debug, Serialize, Deserialize, Clone)]
+pub struct DecryptFinalResponse {
+    pub plain: Blob
+}
+
+/// Initialize multi-part decryption.
+#[derive(Default, Debug, Serialize, Deserialize, Clone)]
+pub struct DecryptInitRequest {
+    #[serde(default)]
+    pub key: Option<SobjectDescriptor>,
+    #[serde(default)]
+    pub alg: Option<Algorithm>,
     /// Mode is required for symmetric algorithms.
     #[serde(default)]
-    pub mode: Option<CryptMode>,
-    /// Initialization vector is optional and will be randomly generated if not specified.
+    pub mode: Option<CipherMode>,
+    /// Initialization vector is required for symmetric algorithms.
     #[serde(default)]
     pub iv: Option<Blob>,
     /// Authenticated data is only applicable when using GCM mode.
     #[serde(default)]
-    pub ad: Option<Blob>,
-    /// Tag length is only applicable when using GCM mode.
-    #[serde(default)]
-    pub tag_len: Option<usize>,
+    pub ad: Option<Blob>
 }
 
-/// Result of an encryption.
+/// Result of initializing multi-part decryption.
 #[derive(Default, Debug, Serialize, Deserialize, Clone)]
-pub struct EncryptResponse {
-    /// Key id is returned for non-transient keys.
+pub struct DecryptInitResponse {
+    /// The key id is returned for non-transient keys.
     #[serde(default)]
     pub kid: Option<Uuid>,
-    pub cipher: Blob,
-    /// Initialization vector is only returned for symmetric encryption.
-    #[serde(default)]
-    pub iv: Option<Blob>,
-    /// Tag is only returned for symmetric encryption with GCM mode.
-    #[serde(default)]
-    pub tag: Option<Blob>,
-}
-
-/// Initialize multi-part encryption. AEAD ciphers are not currently supported in this mode.
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct EncryptInitRequest {
-    #[serde(default)]
-    pub key: Option<SobjectDescriptor>,
-    pub alg: Algorithm,
-    /// Mode is required for symmetric encryption.
-    #[serde(default)]
-    pub mode: Option<CipherMode>,
-    #[serde(default)]
-    pub iv: Option<Blob>,
-}
-
-/// Result of initializing multi-part encryption.
-#[derive(Default, Debug, Serialize, Deserialize, Clone)]
-pub struct EncryptInitResponse {
-    /// Key id is returned for non-transient keys.
-    #[serde(default)]
-    pub kid: Option<Uuid>,
-    /// Initialization vector is only returned for symmetric encryption.
-    #[serde(default)]
-    pub iv: Option<Blob>,
     /// Opaque data, not to be interpreted or modified by the client and must be provided with next request.
-    pub state: Blob,
-}
-
-/// Multi-part encryption request.
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct EncryptUpdateRequest {
-    #[serde(default)]
-    pub key: Option<SobjectDescriptor>,
-    pub plain: Blob,
-    pub state: Blob,
-}
-
-/// Result of multi-part encryption.
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct EncryptUpdateResponse {
-    pub cipher: Blob,
-    /// Opaque data, not to be interpreted or modified by the client and must be provided with next request.
-    pub state: Blob,
-}
-
-/// Finalize a multi-part encryption.
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct EncryptFinalRequest {
-    #[serde(default)]
-    pub key: Option<SobjectDescriptor>,
-    pub state: Blob,
-}
-
-/// Final result of a multi-part encryption.
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct EncryptFinalResponse {
-    pub cipher: Blob,
+    pub state: Blob
 }
 
 /// A request to decrypt data using a symmetric or asymmetric key.
@@ -149,6 +118,12 @@ pub struct DecryptRequest {
     /// Tag is only applicable when using GCM mode.
     #[serde(default)]
     pub tag: Option<Blob>,
+    /// This flag is only useful with `DECRYPT` permission. When this flag is `true`,
+    /// decryption returns masked output. Setting it to `false` is equivalent to not using
+    /// this flag.
+    /// With `MASKDECRYPT` permission, this flag is ignored.
+    #[serde(default)]
+    pub masked: Option<bool>
 }
 
 /// Result of a decryption.
@@ -157,32 +132,7 @@ pub struct DecryptResponse {
     /// The key id of the key used to decrypt. Returned for non-transient keys.
     #[serde(default)]
     pub kid: Option<Uuid>,
-    pub plain: Blob,
-}
-
-/// Initialize multi-part decryption. AEAD ciphers are not currently supported in this mode.
-#[derive(Default, Debug, Serialize, Deserialize, Clone)]
-pub struct DecryptInitRequest {
-    #[serde(default)]
-    pub key: Option<SobjectDescriptor>,
-    #[serde(default)]
-    pub alg: Option<Algorithm>,
-    /// Mode is required for symmetric algorithms.
-    #[serde(default)]
-    pub mode: Option<CipherMode>,
-    /// Initialization vector is required for symmetric algorithms.
-    #[serde(default)]
-    pub iv: Option<Blob>,
-}
-
-/// Result of initializing multi-part decryption.
-#[derive(Default, Debug, Serialize, Deserialize, Clone)]
-pub struct DecryptInitResponse {
-    /// The key id is returned for non-transient keys.
-    #[serde(default)]
-    pub kid: Option<Uuid>,
-    /// Opaque data, not to be interpreted or modified by the client and must be provided with next request.
-    pub state: Blob,
+    pub plain: Blob
 }
 
 /// Multi-part decryption request.
@@ -191,7 +141,7 @@ pub struct DecryptUpdateRequest {
     #[serde(default)]
     pub key: Option<SobjectDescriptor>,
     pub cipher: Blob,
-    pub state: Blob,
+    pub state: Blob
 }
 
 /// Result of multi-part decryption.
@@ -199,73 +149,7 @@ pub struct DecryptUpdateRequest {
 pub struct DecryptUpdateResponse {
     pub plain: Blob,
     /// Opaque data, not to be interpreted or modified by the client and must be provided with next request.
-    pub state: Blob,
-}
-
-/// Finalize a multi-part decryption.
-#[derive(Default, Debug, Serialize, Deserialize, Clone)]
-pub struct DecryptFinalRequest {
-    #[serde(default)]
-    pub key: Option<SobjectDescriptor>,
-    pub state: Blob,
-}
-
-/// Final result of a multi-part decryption.
-#[derive(Default, Debug, Serialize, Deserialize, Clone)]
-pub struct DecryptFinalResponse {
-    pub plain: Blob,
-}
-
-/// Request to compute the hash of arbitrary data.
-#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
-pub struct DigestRequest {
-    pub alg: DigestAlgorithm,
-    pub data: Blob,
-}
-
-/// Result of a hash operation.
-#[derive(Default, Debug, Serialize, Deserialize, Clone)]
-pub struct DigestResponse {
-    pub digest: Blob,
-}
-
-/// Request for HMAC or CMAC operation.
-#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
-pub struct MacRequest {
-    #[serde(default)]
-    pub key: Option<SobjectDescriptor>,
-    #[serde(default)]
-    pub alg: Option<DigestAlgorithm>,
-    pub data: Blob,
-}
-
-/// Result of HMAC or CMAC operation.
-#[derive(Default, Debug, Serialize, Deserialize, Clone)]
-pub struct MacResponse {
-    #[serde(default)]
-    pub kid: Option<Uuid>,
-    /// This field is retained for backward compatibility in API for HMAC.
-    #[serde(default)]
-    pub digest: Option<Blob>,
-    /// The MAC generated for the input data.
-    pub mac: Blob,
-}
-
-/// Rquest to verify a MAC value.
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct VerifyMacRequest {
-    #[serde(default)]
-    pub key: Option<SobjectDescriptor>,
-    /// Algorithm is required for HMAC.
-    #[serde(default)]
-    pub alg: Option<DigestAlgorithm>,
-    pub data: Blob,
-    /// This field is deprecated. Instead you should use the `mac` field.
-    #[serde(default)]
-    pub digest: Option<Blob>,
-    /// Either `digest` or `mac` should be specified.
-    #[serde(default)]
-    pub mac: Option<Blob>,
+    pub state: Blob
 }
 
 /// Encodes the mechanism to be used when deriving a new key from an existing key.
@@ -274,7 +158,9 @@ pub struct VerifyMacRequest {
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum DeriveKeyMechanism {
-    EncryptData(EncryptRequest),
+    EncryptData (
+        EncryptRequest
+    )
 }
 
 /// Request to derive a key.
@@ -306,7 +192,7 @@ pub struct DeriveKeyRequest {
     pub description: Option<String>,
     /// User-defined metadata for this key stored as key-value pairs.
     #[serde(default)]
-    pub custom_metadata: Option<HashMap<String, String>>,
+    pub custom_metadata: Option<HashMap<String,String>>,
     /// Optional array of key operations to be enabled for this security object. If not
     /// provided the service will provide a default set of key operations. Note that if you
     /// provide an empty array, all key operations will be disabled.
@@ -316,113 +202,151 @@ pub struct DeriveKeyRequest {
     pub state: Option<SobjectState>,
     /// If set to true, the derived key will be transient.
     #[serde(default)]
-    pub transient: Option<bool>,
+    pub transient: Option<bool>
 }
 
-/// Mechanism to use for key agreement.
+/// Request to compute the hash of arbitrary data.
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "snake_case")]
-pub enum AgreeKeyMechanism {
-    DiffieHellman,
+pub struct DigestRequest {
+    pub alg: DigestAlgorithm,
+    pub data: Blob
 }
 
-/// Request to perform key agreement.
+/// Result of a hash operation.
+#[derive(Default, Debug, Serialize, Deserialize, Clone)]
+pub struct DigestResponse {
+    pub digest: Blob
+}
+
+/// Finalize a multi-part encryption.
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct AgreeKeyRequest {
-    #[serde(default)]
-    pub activation_date: Option<Time>,
-    #[serde(default)]
-    pub deactivation_date: Option<Time>,
-    pub private_key: SobjectDescriptor,
-    pub public_key: SobjectDescriptor,
-    /// Mechanism to use for key derivation.
-    pub mechanism: AgreeKeyMechanism,
-    /// Name of the agreed-upon key. Key names must be unique within an account.
-    /// The name is ignored for transient keys.
-    pub name: Option<String>,
-    /// Group ID of the security group that this security object should belong to. The user or
-    /// application creating this security object must be a member of this group. If no group is
-    /// specified, the default group for the requesting application will be used.
-    #[serde(default)]
-    pub group_id: Option<Uuid>,
-    /// Type of key to be derived. NB. for security reasons, you shouldn't specify anything but HMAC or Secret.
-    pub key_type: ObjectType,
-    /// Key size in bits. If less than the output size of the algorithm, the secret's most-significant bits will be truncated.
-    pub key_size: u32,
-    pub enabled: bool,
-    #[serde(default)]
-    pub description: Option<String>,
-    /// User-defined metadata for this key stored as key-value pairs.
-    #[serde(default)]
-    pub custom_metadata: Option<HashMap<String, String>>,
-    /// Optional array of key operations to be enabled for this security object. If not
-    /// provided the service will provide a default set of key operations. Note that if you
-    /// provide an empty array, all key operations will be disabled.
-    #[serde(default)]
-    pub key_ops: Option<KeyOperations>,
-    #[serde(default)]
-    pub state: Option<SobjectState>,
-    /// If set to true, the resulting key will be transient.
-    pub transient: bool,
-}
-
-/// `CipherMode` or `RsaEncryptionPadding`, depending on the encryption algorithm.
-#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
-#[serde(untagged)]
-pub enum CryptMode {
-    Symmetric(CipherMode),
-    Rsa(RsaEncryptionPadding),
-}
-
-/// Type of padding to use for RSA encryption. The use of PKCS#1 v1.5 padding is strongly
-/// discouraged, because of its susceptibility to Bleichenbacher's attack. The padding specified
-/// must adhere to the key's encryption policy. If not specified, the default based on the key's
-/// policy will be used.
-#[derive(Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-pub enum RsaEncryptionPadding {
-    /// Optimal Asymmetric Encryption Padding (PKCS#1 v2.1).
-    Oaep { mgf: Mgf },
-    /// PKCS#1 v1.5 padding.
-    Pkcs1V15 {},
-}
-
-/// Request to perform key wrapping.
-#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
-pub struct WrapKeyRequest {
-    /// The wrapping key.
+pub struct EncryptFinalRequest {
     #[serde(default)]
     pub key: Option<SobjectDescriptor>,
-    /// The key to be wrapped.
+    pub state: Blob,
+    /// Tag length is only applicable when using GCM mode.
     #[serde(default)]
-    pub subject: Option<SobjectDescriptor>,
-    /// Id of the key to be wrapped (legacy, mutually exclusive with `subject`).
+    pub tag_len: Option<usize>
+}
+
+/// Final result of a multi-part encryption.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct EncryptFinalResponse {
+    pub cipher: Blob,
+    /// Tag is only returned for symmetric encryption with GCM mode.
+    #[serde(default)]
+    pub tag: Option<Blob>
+}
+
+/// Initialize multi-part encryption.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct EncryptInitRequest {
+    #[serde(default)]
+    pub key: Option<SobjectDescriptor>,
+    pub alg: Algorithm,
+    /// Mode is required for symmetric encryption.
+    #[serde(default)]
+    pub mode: Option<CipherMode>,
+    #[serde(default)]
+    pub iv: Option<Blob>,
+    /// Authenticated data is only applicable when using GCM mode.
+    #[serde(default)]
+    pub ad: Option<Blob>
+}
+
+/// Result of initializing multi-part encryption.
+#[derive(Default, Debug, Serialize, Deserialize, Clone)]
+pub struct EncryptInitResponse {
+    /// Key id is returned for non-transient keys.
     #[serde(default)]
     pub kid: Option<Uuid>,
+    /// Initialization vector is only returned for symmetric encryption.
+    #[serde(default)]
+    pub iv: Option<Blob>,
+    /// Opaque data, not to be interpreted or modified by the client and must be provided with next request.
+    pub state: Blob
+}
+
+/// A request to encrypt data using a symmetric or asymmetric key.
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
+pub struct EncryptRequest {
+    #[serde(default)]
+    pub key: Option<SobjectDescriptor>,
     pub alg: Algorithm,
+    pub plain: Blob,
     /// Mode is required for symmetric algorithms.
     #[serde(default)]
     pub mode: Option<CryptMode>,
+    /// Initialization vector is optional and will be randomly generated if not specified.
     #[serde(default)]
     pub iv: Option<Blob>,
-    /// Authenticated data is only applicable if mode is GCM.
+    /// Authenticated data is only applicable when using GCM mode.
     #[serde(default)]
     pub ad: Option<Blob>,
-    /// Tag length is required when mode is GCM.
+    /// Tag length is only applicable when using GCM mode.
     #[serde(default)]
-    pub tag_len: Option<usize>,
+    pub tag_len: Option<usize>
 }
 
-/// Result of key wrapping operation.
-#[derive(Default, Debug, Serialize, Deserialize, Clone)]
-pub struct WrapKeyResponse {
-    pub wrapped_key: Blob,
-    /// Initialization vector is only returned for symmetric algorithms.
+/// Result of an encryption.
+#[derive(Default, Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
+pub struct EncryptResponse {
+    /// Key id is returned for non-transient keys.
+    #[serde(default)]
+    pub kid: Option<Uuid>,
+    pub cipher: Blob,
+    /// Initialization vector is only returned for symmetric encryption.
     #[serde(default)]
     pub iv: Option<Blob>,
-    /// Tag is only returned for symmetric algorithm with GCM mode.
+    /// Tag is only returned for symmetric encryption with GCM mode.
     #[serde(default)]
-    pub tag: Option<Blob>,
+    pub tag: Option<Blob>
+}
+
+/// Multi-part encryption request.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct EncryptUpdateRequest {
+    #[serde(default)]
+    pub key: Option<SobjectDescriptor>,
+    pub plain: Blob,
+    pub state: Blob
+}
+
+/// Result of multi-part encryption.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct EncryptUpdateResponse {
+    pub cipher: Blob,
+    /// Opaque data, not to be interpreted or modified by the client and must be provided with next request.
+    pub state: Blob
+}
+
+/// Key Format
+#[derive(Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
+pub enum KeyFormat {
+    Default,
+    Pkcs8
+}
+
+/// Request for HMAC or CMAC operation.
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
+pub struct MacRequest {
+    #[serde(default)]
+    pub key: Option<SobjectDescriptor>,
+    #[serde(default)]
+    pub alg: Option<DigestAlgorithm>,
+    pub data: Blob
+}
+
+/// Result of HMAC or CMAC operation.
+#[derive(Default, Debug, Serialize, Deserialize, Clone)]
+pub struct MacResponse {
+    #[serde(default)]
+    pub kid: Option<Uuid>,
+    /// This field is retained for backward compatibility in API for HMAC.
+    #[serde(default)]
+    pub digest: Option<Blob>,
+    /// The MAC generated for the input data.
+    pub mac: Blob
 }
 
 /// Request to perform key unwrapping.
@@ -462,7 +386,7 @@ pub struct UnwrapKeyRequest {
     pub description: Option<String>,
     /// User-defined metadata for the resulting key stored as key-value pairs.
     #[serde(default)]
-    pub custom_metadata: Option<HashMap<String, String>>,
+    pub custom_metadata: Option<HashMap<String,String>>,
     /// Optional array of key operations to be enabled for the resulting security object. If not
     /// provided the service will provide a default set of key operations. Note that if you provide
     /// an empty array, all key operations will be disabled.
@@ -470,100 +394,113 @@ pub struct UnwrapKeyRequest {
     pub key_ops: Option<KeyOperations>,
     #[serde(default)]
     pub transient: Option<bool>,
+    #[serde(default)]
+    pub kcv: Option<String>
 }
 
-pub struct OperationEncrypt;
+/// Rquest to verify a MAC value.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct VerifyMacRequest {
+    #[serde(default)]
+    pub key: Option<SobjectDescriptor>,
+    /// Algorithm is required for HMAC.
+    #[serde(default)]
+    pub alg: Option<DigestAlgorithm>,
+    pub data: Blob,
+    /// This field is deprecated. Instead you should use the `mac` field.
+    #[serde(default)]
+    pub digest: Option<Blob>,
+    /// Either `digest` or `mac` should be specified.
+    #[serde(default)]
+    pub mac: Option<Blob>
+}
+
+/// Request to perform key wrapping.
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
+pub struct WrapKeyRequest {
+    /// The wrapping key.
+    #[serde(default)]
+    pub key: Option<SobjectDescriptor>,
+    /// The key to be wrapped.
+    #[serde(default)]
+    pub subject: Option<SobjectDescriptor>,
+    /// Id of the key to be wrapped (legacy, mutually exclusive with `subject`).
+    #[serde(default)]
+    pub kid: Option<Uuid>,
+    pub alg: Algorithm,
+    /// Mode is required for symmetric algorithms.
+    #[serde(default)]
+    pub mode: Option<CryptMode>,
+    #[serde(default)]
+    pub iv: Option<Blob>,
+    /// Authenticated data is only applicable if mode is GCM.
+    #[serde(default)]
+    pub ad: Option<Blob>,
+    /// Tag length is required when mode is GCM.
+    #[serde(default)]
+    pub tag_len: Option<usize>,
+    #[serde(default)]
+    pub key_format: Option<KeyFormat>
+}
+
+/// Result of key wrapping operation.
+#[derive(Default, Debug, Serialize, Deserialize, Clone)]
+pub struct WrapKeyResponse {
+    pub wrapped_key: Blob,
+    /// Initialization vector is only returned for symmetric algorithms.
+    #[serde(default)]
+    pub iv: Option<Blob>,
+    /// Tag is only returned for symmetric algorithm with GCM mode.
+    #[serde(default)]
+    pub tag: Option<Blob>
+}
+
+pub struct OperationAgree;
 #[allow(unused)]
-impl Operation for OperationEncrypt {
+impl Operation for OperationAgree {
     type PathParams = ();
     type QueryParams = ();
-    type Body = EncryptRequest;
-    type Output = EncryptResponse;
+    type Body = AgreeKeyRequest;
+    type Output = Sobject;
 
     fn method() -> Method {
         Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
-        format!("/crypto/v1/encrypt")
+        format!("/crypto/v1/agree")
     }
 }
 
 impl SdkmsClient {
-    pub fn encrypt(&self, req: &EncryptRequest) -> Result<EncryptResponse> {
-        self.execute::<OperationEncrypt>(req, (), None)
+    pub fn agree(&self, req: &AgreeKeyRequest) -> Result<Sobject> {
+        self.execute::<OperationAgree>(req, (), None)
     }
-    pub fn request_approval_to_encrypt(
-        &self,
-        req: &EncryptRequest,
-        description: Option<String>,
-    ) -> Result<PendingApproval<OperationEncrypt>> {
-        self.request_approval::<OperationEncrypt>(req, (), None, description)
+    pub fn request_approval_to_agree(
+        &self, req: &AgreeKeyRequest,
+        description: Option<String>) -> Result<PendingApproval<OperationAgree>> {
+        self.request_approval::<OperationAgree>(req, (), None, description)
     }
 }
 
-pub struct OperationEncryptInit;
+pub struct OperationCreateDigest;
 #[allow(unused)]
-impl Operation for OperationEncryptInit {
+impl Operation for OperationCreateDigest {
     type PathParams = ();
     type QueryParams = ();
-    type Body = EncryptInitRequest;
-    type Output = EncryptInitResponse;
+    type Body = DigestRequest;
+    type Output = DigestResponse;
 
     fn method() -> Method {
         Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
-        format!("/crypto/v1/encrypt/init")
+        format!("/crypto/v1/digest")
     }
 }
 
 impl SdkmsClient {
-    pub fn encrypt_init(&self, req: &EncryptInitRequest) -> Result<EncryptInitResponse> {
-        self.execute::<OperationEncryptInit>(req, (), None)
-    }
-}
-
-pub struct OperationEncryptUpdate;
-#[allow(unused)]
-impl Operation for OperationEncryptUpdate {
-    type PathParams = ();
-    type QueryParams = ();
-    type Body = EncryptUpdateRequest;
-    type Output = EncryptUpdateResponse;
-
-    fn method() -> Method {
-        Method::POST
-    }
-    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
-        format!("/crypto/v1/encrypt/update")
-    }
-}
-
-impl SdkmsClient {
-    pub fn encrypt_update(&self, req: &EncryptUpdateRequest) -> Result<EncryptUpdateResponse> {
-        self.execute::<OperationEncryptUpdate>(req, (), None)
-    }
-}
-
-pub struct OperationEncryptFinal;
-#[allow(unused)]
-impl Operation for OperationEncryptFinal {
-    type PathParams = ();
-    type QueryParams = ();
-    type Body = EncryptFinalRequest;
-    type Output = EncryptFinalResponse;
-
-    fn method() -> Method {
-        Method::POST
-    }
-    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
-        format!("/crypto/v1/encrypt/final")
-    }
-}
-
-impl SdkmsClient {
-    pub fn encrypt_final(&self, req: &EncryptFinalRequest) -> Result<EncryptFinalResponse> {
-        self.execute::<OperationEncryptFinal>(req, (), None)
+    pub fn create_digest(&self, req: &DigestRequest) -> Result<DigestResponse> {
+        self.execute::<OperationCreateDigest>(req, (), None)
     }
 }
 
@@ -588,11 +525,31 @@ impl SdkmsClient {
         self.execute::<OperationDecrypt>(req, (), None)
     }
     pub fn request_approval_to_decrypt(
-        &self,
-        req: &DecryptRequest,
-        description: Option<String>,
-    ) -> Result<PendingApproval<OperationDecrypt>> {
+        &self, req: &DecryptRequest,
+        description: Option<String>) -> Result<PendingApproval<OperationDecrypt>> {
         self.request_approval::<OperationDecrypt>(req, (), None, description)
+    }
+}
+
+pub struct OperationDecryptFinal;
+#[allow(unused)]
+impl Operation for OperationDecryptFinal {
+    type PathParams = ();
+    type QueryParams = ();
+    type Body = DecryptFinalRequest;
+    type Output = DecryptFinalResponse;
+
+    fn method() -> Method {
+        Method::POST
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/crypto/v1/decrypt/final")
+    }
+}
+
+impl SdkmsClient {
+    pub fn decrypt_final(&self, req: &DecryptFinalRequest) -> Result<DecryptFinalResponse> {
+        self.execute::<OperationDecryptFinal>(req, (), None)
     }
 }
 
@@ -640,25 +597,172 @@ impl SdkmsClient {
     }
 }
 
-pub struct OperationDecryptFinal;
+pub struct OperationDerive;
 #[allow(unused)]
-impl Operation for OperationDecryptFinal {
+impl Operation for OperationDerive {
     type PathParams = ();
     type QueryParams = ();
-    type Body = DecryptFinalRequest;
-    type Output = DecryptFinalResponse;
+    type Body = DeriveKeyRequest;
+    type Output = Sobject;
 
     fn method() -> Method {
         Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
-        format!("/crypto/v1/decrypt/final")
+        format!("/crypto/v1/derive")
     }
 }
 
 impl SdkmsClient {
-    pub fn decrypt_final(&self, req: &DecryptFinalRequest) -> Result<DecryptFinalResponse> {
-        self.execute::<OperationDecryptFinal>(req, (), None)
+    pub fn derive(&self, req: &DeriveKeyRequest) -> Result<Sobject> {
+        self.execute::<OperationDerive>(req, (), None)
+    }
+    pub fn request_approval_to_derive(
+        &self, req: &DeriveKeyRequest,
+        description: Option<String>) -> Result<PendingApproval<OperationDerive>> {
+        self.request_approval::<OperationDerive>(req, (), None, description)
+    }
+}
+
+pub struct OperationEncrypt;
+#[allow(unused)]
+impl Operation for OperationEncrypt {
+    type PathParams = ();
+    type QueryParams = ();
+    type Body = EncryptRequest;
+    type Output = EncryptResponse;
+
+    fn method() -> Method {
+        Method::POST
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/crypto/v1/encrypt")
+    }
+}
+
+impl SdkmsClient {
+    pub fn encrypt(&self, req: &EncryptRequest) -> Result<EncryptResponse> {
+        self.execute::<OperationEncrypt>(req, (), None)
+    }
+    pub fn request_approval_to_encrypt(
+        &self, req: &EncryptRequest,
+        description: Option<String>) -> Result<PendingApproval<OperationEncrypt>> {
+        self.request_approval::<OperationEncrypt>(req, (), None, description)
+    }
+}
+
+pub struct OperationEncryptFinal;
+#[allow(unused)]
+impl Operation for OperationEncryptFinal {
+    type PathParams = ();
+    type QueryParams = ();
+    type Body = EncryptFinalRequest;
+    type Output = EncryptFinalResponse;
+
+    fn method() -> Method {
+        Method::POST
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/crypto/v1/encrypt/final")
+    }
+}
+
+impl SdkmsClient {
+    pub fn encrypt_final(&self, req: &EncryptFinalRequest) -> Result<EncryptFinalResponse> {
+        self.execute::<OperationEncryptFinal>(req, (), None)
+    }
+}
+
+pub struct OperationEncryptInit;
+#[allow(unused)]
+impl Operation for OperationEncryptInit {
+    type PathParams = ();
+    type QueryParams = ();
+    type Body = EncryptInitRequest;
+    type Output = EncryptInitResponse;
+
+    fn method() -> Method {
+        Method::POST
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/crypto/v1/encrypt/init")
+    }
+}
+
+impl SdkmsClient {
+    pub fn encrypt_init(&self, req: &EncryptInitRequest) -> Result<EncryptInitResponse> {
+        self.execute::<OperationEncryptInit>(req, (), None)
+    }
+}
+
+pub struct OperationEncryptUpdate;
+#[allow(unused)]
+impl Operation for OperationEncryptUpdate {
+    type PathParams = ();
+    type QueryParams = ();
+    type Body = EncryptUpdateRequest;
+    type Output = EncryptUpdateResponse;
+
+    fn method() -> Method {
+        Method::POST
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/crypto/v1/encrypt/update")
+    }
+}
+
+impl SdkmsClient {
+    pub fn encrypt_update(&self, req: &EncryptUpdateRequest) -> Result<EncryptUpdateResponse> {
+        self.execute::<OperationEncryptUpdate>(req, (), None)
+    }
+}
+
+pub struct OperationMac;
+#[allow(unused)]
+impl Operation for OperationMac {
+    type PathParams = ();
+    type QueryParams = ();
+    type Body = MacRequest;
+    type Output = MacResponse;
+
+    fn method() -> Method {
+        Method::POST
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/crypto/v1/mac")
+    }
+}
+
+impl SdkmsClient {
+    pub fn mac(&self, req: &MacRequest) -> Result<MacResponse> {
+        self.execute::<OperationMac>(req, (), None)
+    }
+    pub fn request_approval_to_mac(
+        &self, req: &MacRequest,
+        description: Option<String>) -> Result<PendingApproval<OperationMac>> {
+        self.request_approval::<OperationMac>(req, (), None, description)
+    }
+}
+
+pub struct OperationMacVerify;
+#[allow(unused)]
+impl Operation for OperationMacVerify {
+    type PathParams = ();
+    type QueryParams = ();
+    type Body = VerifyMacRequest;
+    type Output = VerifyResponse;
+
+    fn method() -> Method {
+        Method::POST
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/crypto/v1/macverify")
+    }
+}
+
+impl SdkmsClient {
+    pub fn mac_verify(&self, req: &VerifyMacRequest) -> Result<VerifyResponse> {
+        self.execute::<OperationMacVerify>(req, (), None)
     }
 }
 
@@ -683,11 +787,36 @@ impl SdkmsClient {
         self.execute::<OperationSign>(req, (), None)
     }
     pub fn request_approval_to_sign(
-        &self,
-        req: &SignRequest,
-        description: Option<String>,
-    ) -> Result<PendingApproval<OperationSign>> {
+        &self, req: &SignRequest,
+        description: Option<String>) -> Result<PendingApproval<OperationSign>> {
         self.request_approval::<OperationSign>(req, (), None, description)
+    }
+}
+
+pub struct OperationUnwrap;
+#[allow(unused)]
+impl Operation for OperationUnwrap {
+    type PathParams = ();
+    type QueryParams = ();
+    type Body = UnwrapKeyRequest;
+    type Output = Sobject;
+
+    fn method() -> Method {
+        Method::POST
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/crypto/v1/unwrapkey")
+    }
+}
+
+impl SdkmsClient {
+    pub fn unwrap(&self, req: &UnwrapKeyRequest) -> Result<Sobject> {
+        self.execute::<OperationUnwrap>(req, (), None)
+    }
+    pub fn request_approval_to_unwrap(
+        &self, req: &UnwrapKeyRequest,
+        description: Option<String>) -> Result<PendingApproval<OperationUnwrap>> {
+        self.request_approval::<OperationUnwrap>(req, (), None, description)
     }
 }
 
@@ -734,170 +863,9 @@ impl SdkmsClient {
         self.execute::<OperationWrap>(req, (), None)
     }
     pub fn request_approval_to_wrap(
-        &self,
-        req: &WrapKeyRequest,
-        description: Option<String>,
-    ) -> Result<PendingApproval<OperationWrap>> {
+        &self, req: &WrapKeyRequest,
+        description: Option<String>) -> Result<PendingApproval<OperationWrap>> {
         self.request_approval::<OperationWrap>(req, (), None, description)
     }
 }
 
-pub struct OperationUnwrap;
-#[allow(unused)]
-impl Operation for OperationUnwrap {
-    type PathParams = ();
-    type QueryParams = ();
-    type Body = UnwrapKeyRequest;
-    type Output = Sobject;
-
-    fn method() -> Method {
-        Method::POST
-    }
-    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
-        format!("/crypto/v1/unwrapkey")
-    }
-}
-
-impl SdkmsClient {
-    pub fn unwrap(&self, req: &UnwrapKeyRequest) -> Result<Sobject> {
-        self.execute::<OperationUnwrap>(req, (), None)
-    }
-    pub fn request_approval_to_unwrap(
-        &self,
-        req: &UnwrapKeyRequest,
-        description: Option<String>,
-    ) -> Result<PendingApproval<OperationUnwrap>> {
-        self.request_approval::<OperationUnwrap>(req, (), None, description)
-    }
-}
-
-pub struct OperationMac;
-#[allow(unused)]
-impl Operation for OperationMac {
-    type PathParams = ();
-    type QueryParams = ();
-    type Body = MacRequest;
-    type Output = MacResponse;
-
-    fn method() -> Method {
-        Method::POST
-    }
-    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
-        format!("/crypto/v1/mac")
-    }
-}
-
-impl SdkmsClient {
-    pub fn mac(&self, req: &MacRequest) -> Result<MacResponse> {
-        self.execute::<OperationMac>(req, (), None)
-    }
-    pub fn request_approval_to_mac(
-        &self,
-        req: &MacRequest,
-        description: Option<String>,
-    ) -> Result<PendingApproval<OperationMac>> {
-        self.request_approval::<OperationMac>(req, (), None, description)
-    }
-}
-
-pub struct OperationMacVerify;
-#[allow(unused)]
-impl Operation for OperationMacVerify {
-    type PathParams = ();
-    type QueryParams = ();
-    type Body = VerifyMacRequest;
-    type Output = VerifyResponse;
-
-    fn method() -> Method {
-        Method::POST
-    }
-    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
-        format!("/crypto/v1/macverify")
-    }
-}
-
-impl SdkmsClient {
-    pub fn mac_verify(&self, req: &VerifyMacRequest) -> Result<VerifyResponse> {
-        self.execute::<OperationMacVerify>(req, (), None)
-    }
-}
-
-pub struct OperationDerive;
-#[allow(unused)]
-impl Operation for OperationDerive {
-    type PathParams = ();
-    type QueryParams = ();
-    type Body = DeriveKeyRequest;
-    type Output = Sobject;
-
-    fn method() -> Method {
-        Method::POST
-    }
-    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
-        format!("/crypto/v1/derive")
-    }
-}
-
-impl SdkmsClient {
-    pub fn derive(&self, req: &DeriveKeyRequest) -> Result<Sobject> {
-        self.execute::<OperationDerive>(req, (), None)
-    }
-    pub fn request_approval_to_derive(
-        &self,
-        req: &DeriveKeyRequest,
-        description: Option<String>,
-    ) -> Result<PendingApproval<OperationDerive>> {
-        self.request_approval::<OperationDerive>(req, (), None, description)
-    }
-}
-
-pub struct OperationAgree;
-#[allow(unused)]
-impl Operation for OperationAgree {
-    type PathParams = ();
-    type QueryParams = ();
-    type Body = AgreeKeyRequest;
-    type Output = Sobject;
-
-    fn method() -> Method {
-        Method::POST
-    }
-    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
-        format!("/crypto/v1/agree")
-    }
-}
-
-impl SdkmsClient {
-    pub fn agree(&self, req: &AgreeKeyRequest) -> Result<Sobject> {
-        self.execute::<OperationAgree>(req, (), None)
-    }
-    pub fn request_approval_to_agree(
-        &self,
-        req: &AgreeKeyRequest,
-        description: Option<String>,
-    ) -> Result<PendingApproval<OperationAgree>> {
-        self.request_approval::<OperationAgree>(req, (), None, description)
-    }
-}
-
-pub struct OperationCreateDigest;
-#[allow(unused)]
-impl Operation for OperationCreateDigest {
-    type PathParams = ();
-    type QueryParams = ();
-    type Body = DigestRequest;
-    type Output = DigestResponse;
-
-    fn method() -> Method {
-        Method::POST
-    }
-    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
-        format!("/crypto/v1/digest")
-    }
-}
-
-impl SdkmsClient {
-    pub fn create_digest(&self, req: &DigestRequest) -> Result<DigestResponse> {
-        self.execute::<OperationCreateDigest>(req, (), None)
-    }
-}

--- a/src/generated/external_roles_generated.rs
+++ b/src/generated/external_roles_generated.rs
@@ -9,19 +9,19 @@ use super::*;
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ExternalRole {
     pub external_role_id: Uuid,
-    pub groups: HashMap<Uuid,ExternalRoleMapping>,
+    pub groups: HashMap<Uuid, ExternalRoleMapping>,
     pub kind: ExternalRoleKind,
     pub last_synced: Time,
     pub name: String,
     pub source_id: Uuid,
-    pub acct_id: Uuid
+    pub acct_id: Uuid,
 }
 
 /// Type of an external role.
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub enum ExternalRoleKind {
-    LdapGroup
+    LdapGroup,
 }
 
 #[derive(Copy, PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
@@ -29,13 +29,13 @@ pub struct ExternalRoleMapping {
     #[serde(default)]
     pub users: Option<UserGroupRole>,
     #[serde(default)]
-    pub apps: Option<AppPermissions>
+    pub apps: Option<AppPermissions>,
 }
 
 #[derive(Default, Debug, Serialize, Deserialize, Clone)]
 pub struct ExternalRoleRequest {
     #[serde(default)]
-    pub add_groups: Option<HashMap<Uuid,ExternalRoleMapping>>,
+    pub add_groups: Option<HashMap<Uuid, ExternalRoleMapping>>,
     #[serde(default)]
     pub del_groups: Option<HashSet<Uuid>>,
     #[serde(default)]
@@ -43,16 +43,16 @@ pub struct ExternalRoleRequest {
     #[serde(default)]
     pub kind: Option<ExternalRoleKind>,
     #[serde(default)]
-    pub mod_groups: Option<HashMap<Uuid,ExternalRoleMapping>>,
+    pub mod_groups: Option<HashMap<Uuid, ExternalRoleMapping>>,
     #[serde(default)]
     pub name: Option<String>,
     #[serde(default)]
-    pub source_id: Option<Uuid>
+    pub source_id: Option<Uuid>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Default)]
 pub struct ListExternalRolesParams {
-    pub group_id: Option<Uuid>
+    pub group_id: Option<Uuid>,
 }
 
 impl UrlEncode for ListExternalRolesParams {
@@ -99,7 +99,10 @@ impl Operation for OperationDeleteExternalRole {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/external_roles/{id}", id = p.0)
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
+        None
+    }
+}
 
 impl SdkmsClient {
     pub fn delete_external_role(&self, id: &Uuid) -> Result<()> {
@@ -121,7 +124,10 @@ impl Operation for OperationGetExternalRole {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/external_roles/{id}", id = p.0)
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
+        None
+    }
+}
 
 impl SdkmsClient {
     pub fn get_external_role(&self, id: &Uuid) -> Result<ExternalRole> {
@@ -143,10 +149,16 @@ impl Operation for OperationListExternalRoles {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/external_roles?{q}", q = q.encode())
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
+        None
+    }
+}
 
 impl SdkmsClient {
-    pub fn list_external_roles(&self, query_params: Option<&ListExternalRolesParams>) -> Result<Vec<ExternalRole>> {
+    pub fn list_external_roles(
+        &self,
+        query_params: Option<&ListExternalRolesParams>,
+    ) -> Result<Vec<ExternalRole>> {
         self.execute::<OperationListExternalRoles>(&(), (), query_params)
     }
 }
@@ -165,7 +177,10 @@ impl Operation for OperationSyncExternalRole {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/external_roles/{id}/sync", id = p.0)
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
+        None
+    }
+}
 
 impl SdkmsClient {
     pub fn sync_external_role(&self, id: &Uuid) -> Result<ExternalRole> {
@@ -190,8 +205,11 @@ impl Operation for OperationUpdateExternalRole {
 }
 
 impl SdkmsClient {
-    pub fn update_external_role(&self, id: &Uuid, req: &ExternalRoleRequest) -> Result<ExternalRole> {
+    pub fn update_external_role(
+        &self,
+        id: &Uuid,
+        req: &ExternalRoleRequest,
+    ) -> Result<ExternalRole> {
         self.execute::<OperationUpdateExternalRole>(req, (id,), None)
     }
 }
-

--- a/src/generated/groups_generated.rs
+++ b/src/generated/groups_generated.rs
@@ -5,78 +5,301 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::*;
-use serde::{Deserialize, Serialize};
+
+#[derive(PartialEq, Eq, Hash, Debug, Serialize, Deserialize, Clone)]
+pub enum AwskmsRegion {
+    #[serde(rename = "us-east-1")]
+    UsEast1,
+    #[serde(rename = "us-east-2")]
+    UsEast2,
+    #[serde(rename = "us-west-1")]
+    UsWest1,
+    #[serde(rename = "us-west-2")]
+    UsWest2,
+    #[serde(rename = "af-south-1")]
+    AfSouth1,
+    #[serde(rename = "ap-east-1")]
+    ApEast1,
+    #[serde(rename = "ap-southeast-3")]
+    ApSoutheast3,
+    #[serde(rename = "ap-south-1")]
+    ApSouth1,
+    #[serde(rename = "ap-northeast-3")]
+    ApNortheast3,
+    #[serde(rename = "ap-northeast-2")]
+    ApNortheast2,
+    #[serde(rename = "ap-southeast-1")]
+    ApSoutheast1,
+    #[serde(rename = "ap-southeast-2")]
+    ApSoutheast2,
+    #[serde(rename = "ap-northeast-1")]
+    ApNortheast1,
+    #[serde(rename = "ca-central-1")]
+    CaCentral1,
+    #[serde(rename = "eu-central-1")]
+    EuCentral1,
+    #[serde(rename = "eu-west-1")]
+    EuWest1,
+    #[serde(rename = "eu-west-2")]
+    EuWest2,
+    #[serde(rename = "eu-south-1")]
+    EuSouth1,
+    #[serde(rename = "eu-west-3")]
+    EuWest3,
+    #[serde(rename = "eu-north-1")]
+    EuNorth1,
+    #[serde(rename = "me-south-1")]
+    MeSouth1,
+    #[serde(rename = "sa-east-1")]
+    SaEast1,
+    #[serde(rename = "us-gov-east-1")]
+    UsGovEast1,
+    #[serde(rename = "us-gov-west-1")]
+    UsGovWest1
+}
+
+#[derive(PartialEq, Eq, Hash, Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub enum AwskmsService {
+    Kms,
+    KmsFips
+}
+
+#[derive(Debug, Eq, PartialEq, Copy, Hash, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum AzureKeyVaultType {
+    Standard,
+    Premium,
+    Managed
+}
+
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
+pub struct CheckHmgRequest {
+    /// The ID of the hmg configuration in the group.
+    pub id: Option<Uuid>,
+    pub config: Option<HmgConfig>
+}
+
+#[derive(PartialEq, Eq, Hash, Debug, Serialize, Deserialize, Clone)]
+pub struct GcpKeyRingConfig {
+    pub service_account_email: String,
+    pub project_id: String,
+    pub location: String,
+    pub key_ring: Option<String>,
+    pub private_key: Option<Blob>
+}
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Group {
     pub acct_id: Uuid,
     #[serde(default)]
-    pub approval_policy: Option<ApprovalPolicy>,
+    pub approval_policy: Option<GroupApprovalPolicy>,
+    pub client_configurations: ClientConfigurations,
     pub created_at: Time,
     pub creator: Principal,
     #[serde(default)]
+    pub cryptographic_policy: Option<CryptographicPolicy>,
+    #[serde(default)]
+    pub custodian_policy: Option<QuorumPolicy>,
+    #[serde(default)]
+    pub custom_metadata: Option<HashMap<String,String>>,
+    #[serde(default)]
     pub description: Option<String>,
     pub group_id: Uuid,
-    pub name: String,
+    #[serde(default)]
+    pub hmg: Option<HashMap<Uuid,HmgConfig>>,
+    #[serde(default)]
+    pub hmg_redundancy: Option<HmgRedundancyScheme>,
+    #[serde(default)]
+    pub hmg_segregation: Option<bool>,
+    #[serde(default)]
+    pub hmg_sync: Option<bool>,
+    #[serde(default)]
+    pub key_history_policy: Option<KeyHistoryPolicy>,
+    #[serde(default)]
+    pub key_metadata_policy: Option<KeyMetadataPolicy>,
+    pub name: String
+}
+
+/// Group approval policy.
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
+pub struct GroupApprovalPolicy {
+    #[serde(flatten)]
+    pub policy: QuorumPolicy,
+    /// When this is true, manage operations on security objects require approval.
+    pub protect_manage_operations: Option<bool>,
+    /// When this is true, cryptographic operations on security objects require approval.
+    pub protect_crypto_operations: Option<bool>
 }
 
 #[derive(Default, Debug, Serialize, Deserialize, Clone)]
 pub struct GroupRequest {
     #[serde(default)]
-    pub approval_policy: Option<ApprovalPolicy>,
+    pub add_hmg: Option<Vec<HmgConfig>>,
+    #[serde(default)]
+    pub approval_policy: Option<GroupApprovalPolicy>,
+    #[serde(default)]
+    pub client_configurations: Option<ClientConfigurationsRequest>,
+    #[serde(default)]
+    pub cryptographic_policy: Option<Option<CryptographicPolicy>>,
+    #[serde(default)]
+    pub custodian_policy: Option<QuorumPolicy>,
+    #[serde(default)]
+    pub custom_metadata: Option<HashMap<String,String>>,
+    #[serde(default)]
+    pub del_hmg: Option<HashSet<Uuid>>,
     #[serde(default)]
     pub description: Option<String>,
     #[serde(default)]
-    pub name: Option<String>,
+    pub hmg_redundancy: Option<HmgRedundancyScheme>,
+    #[serde(default)]
+    pub hmg_segregation: Option<bool>,
+    #[serde(default)]
+    pub hmg_sync: Option<bool>,
+    #[serde(default)]
+    pub key_history_policy: Option<Option<KeyHistoryPolicy>>,
+    #[serde(default)]
+    pub key_metadata_policy: Option<Option<KeyMetadataPolicy>>,
+    #[serde(default)]
+    pub mod_hmg: Option<HashMap<Uuid,HmgConfig>>,
+    #[serde(default)]
+    pub name: Option<String>
 }
 
-pub struct OperationListGroups;
+#[derive(PartialEq, Eq, Hash, Debug, Serialize, Deserialize, Clone)]
+#[serde(tag = "kind")]
+pub enum HmgConfig {
+    Ncipher {
+        url: String,
+        tls: TlsConfig,
+        slot: usize,
+        #[serde(default)]
+        pin: Option<String>,
+        #[serde(default)]
+        hsm_order: Option<i32>
+    },
+    Safenet {
+        url: String,
+        tls: TlsConfig,
+        slot: usize,
+        #[serde(default)]
+        pin: Option<String>,
+        #[serde(default)]
+        hsm_order: Option<i32>
+    },
+    AwsCloudHsm {
+        url: String,
+        tls: TlsConfig,
+        slot: usize,
+        #[serde(default)]
+        pin: Option<String>,
+        #[serde(default)]
+        hsm_order: Option<i32>
+    },
+    AwsKms {
+        url: String,
+        tls: TlsConfig,
+        #[serde(default)]
+        access_key: Option<String>,
+        #[serde(default)]
+        secret_key: Option<String>,
+        #[serde(default)]
+        region: Option<AwskmsRegion>,
+        #[serde(default)]
+        service: Option<AwskmsService>
+    },
+    Fortanix {
+        url: String,
+        tls: TlsConfig,
+        #[serde(default)]
+        pin: Option<String>
+    },
+    FortanixFipsCluster {
+        url: String,
+        tls: TlsConfig,
+        #[serde(default)]
+        pin: Option<String>
+    },
+    AzureKeyVault {
+        url: String,
+        tls: TlsConfig,
+        #[serde(default)]
+        secret_key: Option<String>,
+        tenant_id: Uuid,
+        client_id: Uuid,
+        subscription_id: Uuid,
+        #[serde(default)]
+        key_vault_type: Option<AzureKeyVaultType>
+    },
+    GcpKeyRing (
+        GcpKeyRingConfig
+    )
+}
+
+#[derive(Eq, Debug, PartialEq, Hash, Copy, Serialize, Deserialize, Clone)]
+pub enum HmgRedundancyScheme {
+    PriorityFailover
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct KeyVault {
+    pub id: String,
+    pub name: String,
+    pub vault_type: AzureKeyVaultType,
+    pub location: String,
+    #[serde(default)]
+    pub tags: Option<HashMap<String,String>>,
+    #[serde(default)]
+    pub retention: Option<u32>,
+    pub uri: String
+}
+
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
+pub struct ScanHmgRequest {
+    pub config: Option<HmgConfig>
+}
+
+pub struct OperationCheckHmg;
 #[allow(unused)]
-impl Operation for OperationListGroups {
-    type PathParams = ();
-    type QueryParams = ();
-    type Body = ();
-    type Output = Vec<Group>;
-
-    fn method() -> Method {
-        Method::GET
-    }
-    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
-        format!("/sys/v1/groups")
-    }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
-        None
-    }
-}
-
-impl SdkmsClient {
-    pub fn list_groups(&self) -> Result<Vec<Group>> {
-        self.execute::<OperationListGroups>(&(), (), None)
-    }
-}
-
-pub struct OperationGetGroup;
-#[allow(unused)]
-impl Operation for OperationGetGroup {
+impl Operation for OperationCheckHmg {
     type PathParams = (Uuid,);
     type QueryParams = ();
-    type Body = ();
-    type Output = Group;
+    type Body = CheckHmgRequest;
+    type Output = ();
 
     fn method() -> Method {
-        Method::GET
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
-        format!("/sys/v1/groups/{id}", id = p.0)
-    }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
-        None
+        format!("/sys/v1/groups/{id}/hmg/check", id = p.0)
     }
 }
 
 impl SdkmsClient {
-    pub fn get_group(&self, id: &Uuid) -> Result<Group> {
-        self.execute::<OperationGetGroup>(&(), (id,), None)
+    pub fn check_hmg(&self, id: &Uuid, req: &CheckHmgRequest) -> Result<()> {
+        self.execute::<OperationCheckHmg>(req, (id,), None)
+    }
+}
+
+pub struct OperationCheckHmgConfig;
+#[allow(unused)]
+impl Operation for OperationCheckHmgConfig {
+    type PathParams = ();
+    type QueryParams = ();
+    type Body = HmgConfig;
+    type Output = ();
+
+    fn method() -> Method {
+        Method::POST
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/sys/v1/groups/hmg/check")
+    }
+}
+
+impl SdkmsClient {
+    pub fn check_hmg_config(&self, req: &HmgConfig) -> Result<()> {
+        self.execute::<OperationCheckHmgConfig>(req, (), None)
     }
 }
 
@@ -102,6 +325,138 @@ impl SdkmsClient {
     }
 }
 
+pub struct OperationDeleteGroup;
+#[allow(unused)]
+impl Operation for OperationDeleteGroup {
+    type PathParams = (Uuid,);
+    type QueryParams = ();
+    type Body = ();
+    type Output = ();
+
+    fn method() -> Method {
+        Method::DELETE
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/sys/v1/groups/{id}", id = p.0)
+    }
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+
+impl SdkmsClient {
+    pub fn delete_group(&self, id: &Uuid) -> Result<()> {
+        self.execute::<OperationDeleteGroup>(&(), (id,), None)
+    }
+}
+
+pub struct OperationGetGcpKeyRings;
+#[allow(unused)]
+impl Operation for OperationGetGcpKeyRings {
+    type PathParams = ();
+    type QueryParams = ();
+    type Body = GcpKeyRingConfig;
+    type Output = Vec<String>;
+
+    fn method() -> Method {
+        Method::POST
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/sys/v1/groups/hmg/gcp_key_rings")
+    }
+}
+
+impl SdkmsClient {
+    pub fn get_gcp_key_rings(&self, req: &GcpKeyRingConfig) -> Result<Vec<String>> {
+        self.execute::<OperationGetGcpKeyRings>(req, (), None)
+    }
+}
+
+pub struct OperationGetGroup;
+#[allow(unused)]
+impl Operation for OperationGetGroup {
+    type PathParams = (Uuid,);
+    type QueryParams = ();
+    type Body = ();
+    type Output = Group;
+
+    fn method() -> Method {
+        Method::GET
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/sys/v1/groups/{id}", id = p.0)
+    }
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+
+impl SdkmsClient {
+    pub fn get_group(&self, id: &Uuid) -> Result<Group> {
+        self.execute::<OperationGetGroup>(&(), (id,), None)
+    }
+}
+
+pub struct OperationGetVaults;
+#[allow(unused)]
+impl Operation for OperationGetVaults {
+    type PathParams = ();
+    type QueryParams = ();
+    type Body = HmgConfig;
+    type Output = Vec<KeyVault>;
+
+    fn method() -> Method {
+        Method::POST
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/sys/v1/groups/hmg/azure_vaults")
+    }
+}
+
+impl SdkmsClient {
+    pub fn get_vaults(&self, req: &HmgConfig) -> Result<Vec<KeyVault>> {
+        self.execute::<OperationGetVaults>(req, (), None)
+    }
+}
+
+pub struct OperationListGroups;
+#[allow(unused)]
+impl Operation for OperationListGroups {
+    type PathParams = ();
+    type QueryParams = ();
+    type Body = ();
+    type Output = Vec<Group>;
+
+    fn method() -> Method {
+        Method::GET
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/sys/v1/groups")
+    }
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+
+impl SdkmsClient {
+    pub fn list_groups(&self) -> Result<Vec<Group>> {
+        self.execute::<OperationListGroups>(&(), (), None)
+    }
+}
+
+pub struct OperationScanHmg;
+#[allow(unused)]
+impl Operation for OperationScanHmg {
+    type PathParams = (Uuid,);
+    type QueryParams = ();
+    type Body = ScanHmgRequest;
+    type Output = Vec<Sobject>;
+
+    fn method() -> Method {
+        Method::POST
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/sys/v1/groups/{id}/hmg/scan", id = p.0)
+    }
+}
+
+impl SdkmsClient {
+    pub fn scan_hmg(&self, id: &Uuid, req: &ScanHmgRequest) -> Result<Vec<Sobject>> {
+        self.execute::<OperationScanHmg>(req, (id,), None)
+    }
+}
+
 pub struct OperationUpdateGroup;
 #[allow(unused)]
 impl Operation for OperationUpdateGroup {
@@ -123,36 +478,9 @@ impl SdkmsClient {
         self.execute::<OperationUpdateGroup>(req, (id,), None)
     }
     pub fn request_approval_to_update_group(
-        &self,
-        id: &Uuid,
-        req: &GroupRequest,
-        description: Option<String>,
-    ) -> Result<PendingApproval<OperationUpdateGroup>> {
+        &self, id: &Uuid, req: &GroupRequest,
+        description: Option<String>) -> Result<PendingApproval<OperationUpdateGroup>> {
         self.request_approval::<OperationUpdateGroup>(req, (id,), None, description)
     }
 }
 
-pub struct OperationDeleteGroup;
-#[allow(unused)]
-impl Operation for OperationDeleteGroup {
-    type PathParams = (Uuid,);
-    type QueryParams = ();
-    type Body = ();
-    type Output = ();
-
-    fn method() -> Method {
-        Method::DELETE
-    }
-    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
-        format!("/sys/v1/groups/{id}", id = p.0)
-    }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
-        None
-    }
-}
-
-impl SdkmsClient {
-    pub fn delete_group(&self, id: &Uuid) -> Result<()> {
-        self.execute::<OperationDeleteGroup>(&(), (id,), None)
-    }
-}

--- a/src/generated/groups_generated.rs
+++ b/src/generated/groups_generated.rs
@@ -55,14 +55,14 @@ pub enum AwskmsRegion {
     #[serde(rename = "us-gov-east-1")]
     UsGovEast1,
     #[serde(rename = "us-gov-west-1")]
-    UsGovWest1
+    UsGovWest1,
 }
 
 #[derive(PartialEq, Eq, Hash, Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub enum AwskmsService {
     Kms,
-    KmsFips
+    KmsFips,
 }
 
 #[derive(Debug, Eq, PartialEq, Copy, Hash, Serialize, Deserialize, Clone)]
@@ -70,14 +70,14 @@ pub enum AwskmsService {
 pub enum AzureKeyVaultType {
     Standard,
     Premium,
-    Managed
+    Managed,
 }
 
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
 pub struct CheckHmgRequest {
     /// The ID of the hmg configuration in the group.
     pub id: Option<Uuid>,
-    pub config: Option<HmgConfig>
+    pub config: Option<HmgConfig>,
 }
 
 #[derive(PartialEq, Eq, Hash, Debug, Serialize, Deserialize, Clone)]
@@ -86,7 +86,7 @@ pub struct GcpKeyRingConfig {
     pub project_id: String,
     pub location: String,
     pub key_ring: Option<String>,
-    pub private_key: Option<Blob>
+    pub private_key: Option<Blob>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -102,12 +102,12 @@ pub struct Group {
     #[serde(default)]
     pub custodian_policy: Option<QuorumPolicy>,
     #[serde(default)]
-    pub custom_metadata: Option<HashMap<String,String>>,
+    pub custom_metadata: Option<HashMap<String, String>>,
     #[serde(default)]
     pub description: Option<String>,
     pub group_id: Uuid,
     #[serde(default)]
-    pub hmg: Option<HashMap<Uuid,HmgConfig>>,
+    pub hmg: Option<HashMap<Uuid, HmgConfig>>,
     #[serde(default)]
     pub hmg_redundancy: Option<HmgRedundancyScheme>,
     #[serde(default)]
@@ -118,7 +118,7 @@ pub struct Group {
     pub key_history_policy: Option<KeyHistoryPolicy>,
     #[serde(default)]
     pub key_metadata_policy: Option<KeyMetadataPolicy>,
-    pub name: String
+    pub name: String,
 }
 
 /// Group approval policy.
@@ -129,7 +129,7 @@ pub struct GroupApprovalPolicy {
     /// When this is true, manage operations on security objects require approval.
     pub protect_manage_operations: Option<bool>,
     /// When this is true, cryptographic operations on security objects require approval.
-    pub protect_crypto_operations: Option<bool>
+    pub protect_crypto_operations: Option<bool>,
 }
 
 #[derive(Default, Debug, Serialize, Deserialize, Clone)]
@@ -145,7 +145,7 @@ pub struct GroupRequest {
     #[serde(default)]
     pub custodian_policy: Option<QuorumPolicy>,
     #[serde(default)]
-    pub custom_metadata: Option<HashMap<String,String>>,
+    pub custom_metadata: Option<HashMap<String, String>>,
     #[serde(default)]
     pub del_hmg: Option<HashSet<Uuid>>,
     #[serde(default)]
@@ -161,9 +161,9 @@ pub struct GroupRequest {
     #[serde(default)]
     pub key_metadata_policy: Option<Option<KeyMetadataPolicy>>,
     #[serde(default)]
-    pub mod_hmg: Option<HashMap<Uuid,HmgConfig>>,
+    pub mod_hmg: Option<HashMap<Uuid, HmgConfig>>,
     #[serde(default)]
-    pub name: Option<String>
+    pub name: Option<String>,
 }
 
 #[derive(PartialEq, Eq, Hash, Debug, Serialize, Deserialize, Clone)]
@@ -176,7 +176,7 @@ pub enum HmgConfig {
         #[serde(default)]
         pin: Option<String>,
         #[serde(default)]
-        hsm_order: Option<i32>
+        hsm_order: Option<i32>,
     },
     Safenet {
         url: String,
@@ -185,7 +185,7 @@ pub enum HmgConfig {
         #[serde(default)]
         pin: Option<String>,
         #[serde(default)]
-        hsm_order: Option<i32>
+        hsm_order: Option<i32>,
     },
     AwsCloudHsm {
         url: String,
@@ -194,7 +194,7 @@ pub enum HmgConfig {
         #[serde(default)]
         pin: Option<String>,
         #[serde(default)]
-        hsm_order: Option<i32>
+        hsm_order: Option<i32>,
     },
     AwsKms {
         url: String,
@@ -206,19 +206,19 @@ pub enum HmgConfig {
         #[serde(default)]
         region: Option<AwskmsRegion>,
         #[serde(default)]
-        service: Option<AwskmsService>
+        service: Option<AwskmsService>,
     },
     Fortanix {
         url: String,
         tls: TlsConfig,
         #[serde(default)]
-        pin: Option<String>
+        pin: Option<String>,
     },
     FortanixFipsCluster {
         url: String,
         tls: TlsConfig,
         #[serde(default)]
-        pin: Option<String>
+        pin: Option<String>,
     },
     AzureKeyVault {
         url: String,
@@ -229,16 +229,14 @@ pub enum HmgConfig {
         client_id: Uuid,
         subscription_id: Uuid,
         #[serde(default)]
-        key_vault_type: Option<AzureKeyVaultType>
+        key_vault_type: Option<AzureKeyVaultType>,
     },
-    GcpKeyRing (
-        GcpKeyRingConfig
-    )
+    GcpKeyRing(GcpKeyRingConfig),
 }
 
 #[derive(Eq, Debug, PartialEq, Hash, Copy, Serialize, Deserialize, Clone)]
 pub enum HmgRedundancyScheme {
-    PriorityFailover
+    PriorityFailover,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -248,15 +246,15 @@ pub struct KeyVault {
     pub vault_type: AzureKeyVaultType,
     pub location: String,
     #[serde(default)]
-    pub tags: Option<HashMap<String,String>>,
+    pub tags: Option<HashMap<String, String>>,
     #[serde(default)]
     pub retention: Option<u32>,
-    pub uri: String
+    pub uri: String,
 }
 
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
 pub struct ScanHmgRequest {
-    pub config: Option<HmgConfig>
+    pub config: Option<HmgConfig>,
 }
 
 pub struct OperationCheckHmg;
@@ -339,7 +337,10 @@ impl Operation for OperationDeleteGroup {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/groups/{id}", id = p.0)
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
+        None
+    }
+}
 
 impl SdkmsClient {
     pub fn delete_group(&self, id: &Uuid) -> Result<()> {
@@ -383,7 +384,10 @@ impl Operation for OperationGetGroup {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/groups/{id}", id = p.0)
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
+        None
+    }
+}
 
 impl SdkmsClient {
     pub fn get_group(&self, id: &Uuid) -> Result<Group> {
@@ -427,7 +431,10 @@ impl Operation for OperationListGroups {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/groups")
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
+        None
+    }
+}
 
 impl SdkmsClient {
     pub fn list_groups(&self) -> Result<Vec<Group>> {
@@ -478,9 +485,11 @@ impl SdkmsClient {
         self.execute::<OperationUpdateGroup>(req, (id,), None)
     }
     pub fn request_approval_to_update_group(
-        &self, id: &Uuid, req: &GroupRequest,
-        description: Option<String>) -> Result<PendingApproval<OperationUpdateGroup>> {
+        &self,
+        id: &Uuid,
+        req: &GroupRequest,
+        description: Option<String>,
+    ) -> Result<PendingApproval<OperationUpdateGroup>> {
         self.request_approval::<OperationUpdateGroup>(req, (id,), None, description)
     }
 }
-

--- a/src/generated/keys_generated.rs
+++ b/src/generated/keys_generated.rs
@@ -11,7 +11,7 @@ use super::*;
 pub struct CopySobjectRequest {
     pub key: SobjectDescriptor,
     #[serde(flatten)]
-    pub dest: SobjectRequest
+    pub dest: SobjectRequest,
 }
 
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
@@ -20,7 +20,7 @@ pub struct ExportComponentsResponse {
     pub iv: Option<Blob>,
     pub tag: Option<Blob>,
     pub key_kcv: Option<String>,
-    pub description: Option<String>
+    pub description: Option<String>,
 }
 
 /// Request to Export a Sobject by components
@@ -33,19 +33,7 @@ pub struct ExportSobjectComponentsRequest {
     #[serde(default)]
     pub method: Option<SplittingMethod>,
     #[serde(default)]
-    pub description: Option<String>
-}
-
-#[derive(Debug, PartialEq, Serialize, Deserialize, Clone, Default)]
-pub struct FilterList {
-    #[serde(flatten)]
-    pub head: Box<CustomMetadata>
-}
-
-impl UrlEncode for FilterList {
-    fn url_encode(&self, m: &mut HashMap<String, String>) {
-        self.head.url_encode(m);
-    }
+    pub description: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Default)]
@@ -54,13 +42,16 @@ pub struct GetSobjectParams {
     pub show_destroyed: bool,
     pub show_deleted: bool,
     pub show_value: bool,
-    pub show_pub_key: bool
+    pub show_pub_key: bool,
 }
 
 impl UrlEncode for GetSobjectParams {
     fn url_encode(&self, m: &mut HashMap<String, String>) {
         m.insert("view".to_string(), self.view.to_string());
-        m.insert("show_destroyed".to_string(), self.show_destroyed.to_string());
+        m.insert(
+            "show_destroyed".to_string(),
+            self.show_destroyed.to_string(),
+        );
         m.insert("show_deleted".to_string(), self.show_deleted.to_string());
         m.insert("show_value".to_string(), self.show_value.to_string());
         m.insert("show_pub_key".to_string(), self.show_pub_key.to_string());
@@ -79,7 +70,7 @@ pub struct ImportSobjectComponentsRequest {
     #[serde(default)]
     pub method: Option<SplittingMethod>,
     #[serde(default)]
-    pub auth_config: Option<ApprovalAuthConfig>
+    pub auth_config: Option<ApprovalAuthConfig>,
 }
 
 /// KCV of a key
@@ -87,7 +78,7 @@ pub struct ImportSobjectComponentsRequest {
 pub struct KeyCheckValueResponse {
     #[serde(default)]
     pub kid: Option<Uuid>,
-    pub kcv: String
+    pub kcv: String,
 }
 
 #[derive(PartialEq, Debug, Serialize, Deserialize, Clone, Default)]
@@ -111,7 +102,7 @@ pub struct ListSobjectsParams {
     pub show_value: bool,
     pub show_pub_key: bool,
     #[serde(default)]
-    pub filter: Option<FilterList>
+    pub filter: Option<String>,
 }
 
 impl UrlEncode for ListSobjectsParams {
@@ -148,12 +139,15 @@ impl UrlEncode for ListSobjectsParams {
         if let Some(ref v) = self.with_metadata {
             m.insert("with_metadata".to_string(), v.to_string());
         }
-        m.insert("show_destroyed".to_string(), self.show_destroyed.to_string());
+        m.insert(
+            "show_destroyed".to_string(),
+            self.show_destroyed.to_string(),
+        );
         m.insert("show_deleted".to_string(), self.show_deleted.to_string());
         m.insert("show_value".to_string(), self.show_value.to_string());
         m.insert("show_pub_key".to_string(), self.show_pub_key.to_string());
         if let Some(ref v) = self.filter {
-            m.insert("filter".to_string(), v.head.encode());
+            m.insert("filter".to_string(), v.to_string());
         }
     }
 }
@@ -161,14 +155,14 @@ impl UrlEncode for ListSobjectsParams {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Metadata {
     pub total_count: usize,
-    pub filtered_count: usize
+    pub filtered_count: usize,
 }
 
 /// Request to compute digest of a key.
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
 pub struct ObjectDigestRequest {
     pub key: SobjectDescriptor,
-    pub alg: DigestAlgorithm
+    pub alg: DigestAlgorithm,
 }
 
 /// Digest of a key.
@@ -176,7 +170,7 @@ pub struct ObjectDigestRequest {
 pub struct ObjectDigestResponse {
     #[serde(default)]
     pub kid: Option<Uuid>,
-    pub digest: Blob
+    pub digest: Blob,
 }
 
 /// Request to persist a transient key.
@@ -192,7 +186,7 @@ pub struct PersistTransientKeyRequest {
     pub description: Option<String>,
     /// User-defined metadata for the persisted key stored as key-value pairs.
     #[serde(default)]
-    pub custom_metadata: Option<HashMap<String,String>>,
+    pub custom_metadata: Option<HashMap<String, String>>,
     /// Whether the new security object should be enabled. Disabled security objects may not perform cryptographic operations.
     #[serde(default)]
     pub enabled: Option<bool>,
@@ -204,12 +198,12 @@ pub struct PersistTransientKeyRequest {
     #[serde(default)]
     pub state: Option<SobjectState>,
     /// Transient key to persist.
-    pub transient_key: Blob
+    pub transient_key: Blob,
 }
 
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
 pub struct RevertRequest {
-    pub ids: Vec<Uuid>
+    pub ids: Vec<Uuid>,
 }
 
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
@@ -217,14 +211,14 @@ pub struct RevertRequest {
 pub struct SobjectComponent {
     pub component: Blob,
     pub component_kcv: Option<String>,
-    pub custodian: Principal
+    pub custodian: Principal,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum SobjectEncoding {
     Json,
-    Value
+    Value,
 }
 
 /// Request to rekey a security object
@@ -232,7 +226,7 @@ pub enum SobjectEncoding {
 pub struct SobjectRekeyRequest {
     pub deactivate_rotated_key: bool,
     #[serde(flatten)]
-    pub dest: SobjectRequest
+    pub dest: SobjectRequest,
 }
 
 #[derive(Default, Debug, Serialize, Deserialize, Clone)]
@@ -242,7 +236,7 @@ pub struct SobjectRequest {
     #[serde(default)]
     pub aes: Option<AesOptions>,
     #[serde(default)]
-    pub custom_metadata: Option<HashMap<String,String>>,
+    pub custom_metadata: Option<HashMap<String, String>>,
     #[serde(default)]
     pub deactivation_date: Option<Time>,
     #[serde(default)]
@@ -296,31 +290,31 @@ pub struct SobjectRequest {
     #[serde(default)]
     pub value: Option<Blob>,
     #[serde(default)]
-    pub group_id: Option<Uuid>
+    pub group_id: Option<Uuid>,
 }
 
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
 pub enum SobjectSort {
-    ByKid {
-        order: Order,
-        start: Option<Uuid>
-    },
-    ByName {
-        order: Order,
-        start: Option<String>
-    }
+    ByKid { order: Order, start: Option<Uuid> },
+    ByName { order: Order, start: Option<String> },
 }
 
 impl UrlEncode for SobjectSort {
     fn url_encode(&self, m: &mut HashMap<String, String>) {
         match *self {
-            SobjectSort::ByKid{ ref order, ref start } => {
+            SobjectSort::ByKid {
+                ref order,
+                ref start,
+            } => {
                 m.insert("sort".to_string(), format!("kid:{}", order));
                 if let Some(v) = start {
                     m.insert("start".to_string(), v.to_string());
                 }
             }
-            SobjectSort::ByName{ ref order, ref start } => {
+            SobjectSort::ByName {
+                ref order,
+                ref start,
+            } => {
                 m.insert("sort".to_string(), format!("name:{}", order));
                 if let Some(v) = start {
                     m.insert("start".to_string(), v.to_string());
@@ -332,7 +326,7 @@ impl UrlEncode for SobjectSort {
 
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
 pub enum SplittingMethod {
-    XOR
+    XOR,
 }
 
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
@@ -350,7 +344,7 @@ pub struct UnwrapKeyParams {
     pub ad: Option<Blob>,
     /// Tag is required if mode is GCM.
     #[serde(default)]
-    pub tag: Option<Blob>
+    pub tag: Option<Blob>,
 }
 
 /// Verify KCV of a key
@@ -358,12 +352,12 @@ pub struct UnwrapKeyParams {
 pub struct VerifyKcvRequest {
     pub kcv: String,
     pub value: Blob,
-    pub obj_type: ObjectType
+    pub obj_type: ObjectType,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct VerifyKcvResponse {
-    pub verified: bool
+    pub verified: bool,
 }
 
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
@@ -381,7 +375,7 @@ pub struct WrapKeyParams {
     pub ad: Option<Blob>,
     /// Tag length is required when mode is GCM.
     #[serde(default)]
-    pub tag_len: Option<usize>
+    pub tag_len: Option<usize>,
 }
 
 pub struct OperationActivateSobject;
@@ -398,7 +392,10 @@ impl Operation for OperationActivateSobject {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/crypto/v1/keys/{id}/activate", id = p.0)
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
+        None
+    }
+}
 
 impl SdkmsClient {
     pub fn activate_sobject(&self, id: &Uuid) -> Result<()> {
@@ -423,12 +420,17 @@ impl Operation for OperationBatchSign {
 }
 
 impl SdkmsClient {
-    pub fn batch_sign(&self, req: &Vec<SignRequest>) -> Result<Vec<BatchResponseItem<SignResponse>>> {
+    pub fn batch_sign(
+        &self,
+        req: &Vec<SignRequest>,
+    ) -> Result<Vec<BatchResponseItem<SignResponse>>> {
         self.execute::<OperationBatchSign>(req, (), None)
     }
     pub fn request_approval_to_batch_sign(
-        &self, req: &Vec<SignRequest>,
-        description: Option<String>) -> Result<PendingApproval<OperationBatchSign>> {
+        &self,
+        req: &Vec<SignRequest>,
+        description: Option<String>,
+    ) -> Result<PendingApproval<OperationBatchSign>> {
         self.request_approval::<OperationBatchSign>(req, (), None, description)
     }
 }
@@ -450,7 +452,10 @@ impl Operation for OperationBatchVerify {
 }
 
 impl SdkmsClient {
-    pub fn batch_verify(&self, req: &Vec<VerifyRequest>) -> Result<Vec<BatchResponseItem<VerifyResponse>>> {
+    pub fn batch_verify(
+        &self,
+        req: &Vec<VerifyRequest>,
+    ) -> Result<Vec<BatchResponseItem<VerifyResponse>>> {
         self.execute::<OperationBatchVerify>(req, (), None)
     }
 }
@@ -476,8 +481,10 @@ impl SdkmsClient {
         self.execute::<OperationCopySobject>(req, (), None)
     }
     pub fn request_approval_to_copy_sobject(
-        &self, req: &CopySobjectRequest,
-        description: Option<String>) -> Result<PendingApproval<OperationCopySobject>> {
+        &self,
+        req: &CopySobjectRequest,
+        description: Option<String>,
+    ) -> Result<PendingApproval<OperationCopySobject>> {
         self.request_approval::<OperationCopySobject>(req, (), None, description)
     }
 }
@@ -518,15 +525,20 @@ impl Operation for OperationDeleteSobject {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/crypto/v1/keys/{id}", id = p.0)
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
+        None
+    }
+}
 
 impl SdkmsClient {
     pub fn delete_sobject(&self, id: &Uuid) -> Result<()> {
         self.execute::<OperationDeleteSobject>(&(), (id,), None)
     }
     pub fn request_approval_to_delete_sobject(
-        &self, id: &Uuid,
-        description: Option<String>) -> Result<PendingApproval<OperationDeleteSobject>> {
+        &self,
+        id: &Uuid,
+        description: Option<String>,
+    ) -> Result<PendingApproval<OperationDeleteSobject>> {
         self.request_approval::<OperationDeleteSobject>(&(), (id,), None, description)
     }
 }
@@ -545,15 +557,20 @@ impl Operation for OperationDestroySobject {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/crypto/v1/keys/{id}/destroy", id = p.0)
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
+        None
+    }
+}
 
 impl SdkmsClient {
     pub fn destroy_sobject(&self, id: &Uuid) -> Result<()> {
         self.execute::<OperationDestroySobject>(&(), (id,), None)
     }
     pub fn request_approval_to_destroy_sobject(
-        &self, id: &Uuid,
-        description: Option<String>) -> Result<PendingApproval<OperationDestroySobject>> {
+        &self,
+        id: &Uuid,
+        description: Option<String>,
+    ) -> Result<PendingApproval<OperationDestroySobject>> {
         self.request_approval::<OperationDestroySobject>(&(), (id,), None, description)
     }
 }
@@ -601,8 +618,10 @@ impl SdkmsClient {
         self.execute::<OperationExportSobject>(req, (), None)
     }
     pub fn request_approval_to_export_sobject(
-        &self, req: &SobjectDescriptor,
-        description: Option<String>) -> Result<PendingApproval<OperationExportSobject>> {
+        &self,
+        req: &SobjectDescriptor,
+        description: Option<String>,
+    ) -> Result<PendingApproval<OperationExportSobject>> {
         self.request_approval::<OperationExportSobject>(req, (), None, description)
     }
 }
@@ -624,12 +643,17 @@ impl Operation for OperationExportSobjectComponents {
 }
 
 impl SdkmsClient {
-    pub fn export_sobject_components(&self, req: &ExportSobjectComponentsRequest) -> Result<ExportComponentsResponse> {
+    pub fn export_sobject_components(
+        &self,
+        req: &ExportSobjectComponentsRequest,
+    ) -> Result<ExportComponentsResponse> {
         self.execute::<OperationExportSobjectComponents>(req, (), None)
     }
     pub fn request_approval_to_export_sobject_components(
-        &self, req: &ExportSobjectComponentsRequest,
-        description: Option<String>) -> Result<PendingApproval<OperationExportSobjectComponents>> {
+        &self,
+        req: &ExportSobjectComponentsRequest,
+        description: Option<String>,
+    ) -> Result<PendingApproval<OperationExportSobjectComponents>> {
         self.request_approval::<OperationExportSobjectComponents>(req, (), None, description)
     }
 }
@@ -659,10 +683,10 @@ impl SdkmsClient {
 pub struct OperationGetPubkey;
 #[allow(unused)]
 impl Operation for OperationGetPubkey {
-    type PathParams = (Uuid, String,);
+    type PathParams = (Uuid, String);
     type QueryParams = ();
     type Body = ();
-    type Output = HashMap<String,Blob>;
+    type Output = HashMap<String, Blob>;
 
     fn method() -> Method {
         Method::GET
@@ -670,11 +694,14 @@ impl Operation for OperationGetPubkey {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/crypto/v1/pubkey/{id}/{name}", id = p.0, name = p.1)
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
+        None
+    }
+}
 
 impl SdkmsClient {
-    pub fn get_pubkey(&self, id: &Uuid, name: &String) -> Result<HashMap<String,Blob>> {
-        self.execute::<OperationGetPubkey>(&(), (id, name,), None)
+    pub fn get_pubkey(&self, id: &Uuid, name: &String) -> Result<HashMap<String, Blob>> {
+        self.execute::<OperationGetPubkey>(&(), (id, name), None)
     }
 }
 
@@ -695,7 +722,11 @@ impl Operation for OperationGetSobject {
 }
 
 impl SdkmsClient {
-    pub fn get_sobject(&self, query_params: Option<&GetSobjectParams>, req: &SobjectDescriptor) -> Result<Sobject> {
+    pub fn get_sobject(
+        &self,
+        query_params: Option<&GetSobjectParams>,
+        req: &SobjectDescriptor,
+    ) -> Result<Sobject> {
         self.execute::<OperationGetSobject>(req, (), query_params)
     }
 }
@@ -739,12 +770,17 @@ impl Operation for OperationImportSobjectByComponents {
 }
 
 impl SdkmsClient {
-    pub fn import_sobject_by_components(&self, req: &ImportSobjectComponentsRequest) -> Result<Sobject> {
+    pub fn import_sobject_by_components(
+        &self,
+        req: &ImportSobjectComponentsRequest,
+    ) -> Result<Sobject> {
         self.execute::<OperationImportSobjectByComponents>(req, (), None)
     }
     pub fn request_approval_to_import_sobject_by_components(
-        &self, req: &ImportSobjectComponentsRequest,
-        description: Option<String>) -> Result<PendingApproval<OperationImportSobjectByComponents>> {
+        &self,
+        req: &ImportSobjectComponentsRequest,
+        description: Option<String>,
+    ) -> Result<PendingApproval<OperationImportSobjectByComponents>> {
         self.request_approval::<OperationImportSobjectByComponents>(req, (), None, description)
     }
 }
@@ -763,10 +799,16 @@ impl Operation for OperationListSobjects {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/crypto/v1/keys?{q}", q = q.encode())
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
+        None
+    }
+}
 
 impl SdkmsClient {
-    pub fn list_sobjects(&self, query_params: Option<&ListSobjectsParams>) -> Result<GetAllResponse> {
+    pub fn list_sobjects(
+        &self,
+        query_params: Option<&ListSobjectsParams>,
+    ) -> Result<GetAllResponse> {
         self.execute::<OperationListSobjects>(&(), (), query_params)
     }
 }
@@ -807,15 +849,20 @@ impl Operation for OperationRemovePrivate {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/crypto/v1/keys/{id}/private", id = p.0)
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
+        None
+    }
+}
 
 impl SdkmsClient {
     pub fn remove_private(&self, id: &Uuid) -> Result<()> {
         self.execute::<OperationRemovePrivate>(&(), (id,), None)
     }
     pub fn request_approval_to_remove_private(
-        &self, id: &Uuid,
-        description: Option<String>) -> Result<PendingApproval<OperationRemovePrivate>> {
+        &self,
+        id: &Uuid,
+        description: Option<String>,
+    ) -> Result<PendingApproval<OperationRemovePrivate>> {
         self.request_approval::<OperationRemovePrivate>(&(), (id,), None, description)
     }
 }
@@ -841,8 +888,11 @@ impl SdkmsClient {
         self.execute::<OperationRevertPrevKeyOp>(req, (id,), None)
     }
     pub fn request_approval_to_revert_prev_key_op(
-        &self, id: &Uuid, req: &RevertRequest,
-        description: Option<String>) -> Result<PendingApproval<OperationRevertPrevKeyOp>> {
+        &self,
+        id: &Uuid,
+        req: &RevertRequest,
+        description: Option<String>,
+    ) -> Result<PendingApproval<OperationRevertPrevKeyOp>> {
         self.request_approval::<OperationRevertPrevKeyOp>(req, (id,), None, description)
     }
 }
@@ -868,8 +918,11 @@ impl SdkmsClient {
         self.execute::<OperationRevokeSobject>(req, (id,), None)
     }
     pub fn request_approval_to_revoke_sobject(
-        &self, id: &Uuid, req: &RevocationReason,
-        description: Option<String>) -> Result<PendingApproval<OperationRevokeSobject>> {
+        &self,
+        id: &Uuid,
+        req: &RevocationReason,
+        description: Option<String>,
+    ) -> Result<PendingApproval<OperationRevokeSobject>> {
         self.request_approval::<OperationRevokeSobject>(req, (id,), None, description)
     }
 }
@@ -895,8 +948,10 @@ impl SdkmsClient {
         self.execute::<OperationRotateSobject>(req, (), None)
     }
     pub fn request_approval_to_rotate_sobject(
-        &self, req: &SobjectRekeyRequest,
-        description: Option<String>) -> Result<PendingApproval<OperationRotateSobject>> {
+        &self,
+        req: &SobjectRekeyRequest,
+        description: Option<String>,
+    ) -> Result<PendingApproval<OperationRotateSobject>> {
         self.request_approval::<OperationRotateSobject>(req, (), None, description)
     }
 }
@@ -922,8 +977,11 @@ impl SdkmsClient {
         self.execute::<OperationUpdateSobject>(req, (id,), None)
     }
     pub fn request_approval_to_update_sobject(
-        &self, id: &Uuid, req: &SobjectRequest,
-        description: Option<String>) -> Result<PendingApproval<OperationUpdateSobject>> {
+        &self,
+        id: &Uuid,
+        req: &SobjectRequest,
+        description: Option<String>,
+    ) -> Result<PendingApproval<OperationUpdateSobject>> {
         self.request_approval::<OperationUpdateSobject>(req, (id,), None, description)
     }
 }
@@ -949,4 +1007,3 @@ impl SdkmsClient {
         self.execute::<OperationVerifyKcv>(req, (), None)
     }
 }
-

--- a/src/generated/keys_generated.rs
+++ b/src/generated/keys_generated.rs
@@ -36,7 +36,7 @@ pub struct ExportSobjectComponentsRequest {
     pub description: Option<String>
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize, Clone, )]
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone, Default)]
 pub struct FilterList {
     #[serde(flatten)]
     pub head: Box<CustomMetadata>
@@ -261,6 +261,10 @@ pub struct SobjectRequest {
     pub enabled: Option<bool>,
     #[serde(default)]
     pub fpe: Option<FpeOptions>,
+    /// Key Access Justifications for GCP EKM.
+    /// For more details: https://cloud.google.com/cloud-provider-access-management/key-access-justifications/docs/overview
+    #[serde(default)]
+    pub google_access_reason_policy: Option<GoogleAccessReasonPolicy>,
     #[serde(default)]
     pub kcv: Option<String>,
     #[serde(default)]

--- a/src/generated/keys_generated.rs
+++ b/src/generated/keys_generated.rs
@@ -5,55 +5,170 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::*;
-use serde::{Deserialize, Serialize};
 
-#[derive(Default, Debug, Serialize, Deserialize, Clone)]
-pub struct SobjectRequest {
+/// Request to copy a security object
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CopySobjectRequest {
+    pub key: SobjectDescriptor,
+    #[serde(flatten)]
+    pub dest: SobjectRequest
+}
+
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
+pub struct ExportComponentsResponse {
+    pub components: Vec<SobjectComponent>,
+    pub iv: Option<Blob>,
+    pub tag: Option<Blob>,
+    pub key_kcv: Option<String>,
+    pub description: Option<String>
+}
+
+/// Request to Export a Sobject by components
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "snake_case")]
+pub struct ExportSobjectComponentsRequest {
+    pub key: SobjectDescriptor,
+    pub wrap_key_params: Option<WrapKeyParams>,
+    pub custodians: Vec<Principal>,
     #[serde(default)]
-    pub activation_date: Option<Time>,
+    pub method: Option<SplittingMethod>,
     #[serde(default)]
-    pub custom_metadata: Option<HashMap<String, String>>,
-    #[serde(default)]
-    pub deactivation_date: Option<Time>,
+    pub description: Option<String>
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone, )]
+pub struct FilterList {
+    #[serde(flatten)]
+    pub head: Box<CustomMetadata>
+}
+
+impl UrlEncode for FilterList {
+    fn url_encode(&self, m: &mut HashMap<String, String>) {
+        self.head.url_encode(m);
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Default)]
+pub struct GetSobjectParams {
+    pub view: SobjectEncoding,
+    pub show_destroyed: bool,
+    pub show_deleted: bool,
+    pub show_value: bool,
+    pub show_pub_key: bool
+}
+
+impl UrlEncode for GetSobjectParams {
+    fn url_encode(&self, m: &mut HashMap<String, String>) {
+        m.insert("view".to_string(), self.view.to_string());
+        m.insert("show_destroyed".to_string(), self.show_destroyed.to_string());
+        m.insert("show_deleted".to_string(), self.show_deleted.to_string());
+        m.insert("show_value".to_string(), self.show_value.to_string());
+        m.insert("show_pub_key".to_string(), self.show_pub_key.to_string());
+    }
+}
+
+/// Request to Import a Sobject by components
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ImportSobjectComponentsRequest {
+    pub key: SobjectRequest,
+    pub unwrap_key_params: Option<UnwrapKeyParams>,
+    pub custodians: Vec<Principal>,
+    pub components: Option<Vec<SobjectComponent>>,
     #[serde(default)]
     pub description: Option<String>,
     #[serde(default)]
-    pub deterministic_signatures: Option<bool>,
+    pub method: Option<SplittingMethod>,
     #[serde(default)]
-    pub elliptic_curve: Option<EllipticCurve>,
+    pub auth_config: Option<ApprovalAuthConfig>
+}
+
+/// KCV of a key
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct KeyCheckValueResponse {
     #[serde(default)]
-    pub enabled: Option<bool>,
-    #[serde(default)]
-    pub fpe: Option<FpeOptions>,
-    #[serde(default)]
-    pub key_ops: Option<KeyOperations>,
-    #[serde(default)]
-    pub key_size: Option<u32>,
-    #[serde(default)]
-    pub name: Option<String>,
-    #[serde(default)]
-    pub obj_type: Option<ObjectType>,
-    #[serde(default)]
-    pub pub_exponent: Option<u32>,
-    #[serde(default)]
-    pub publish_public_key: Option<PublishPublicKeyConfig>,
-    #[serde(default)]
-    pub rsa: Option<RsaOptions>,
-    #[serde(default)]
-    pub state: Option<SobjectState>,
-    #[serde(default)]
-    pub transient: Option<bool>,
-    #[serde(default)]
-    pub value: Option<Blob>,
-    #[serde(default)]
+    pub kid: Option<Uuid>,
+    pub kcv: String
+}
+
+#[derive(PartialEq, Debug, Serialize, Deserialize, Clone, Default)]
+pub struct ListSobjectsParams {
     pub group_id: Option<Uuid>,
+    pub creator: Option<Uuid>,
+    pub name: Option<String>,
+    pub pkcs11_label: Option<String>,
+    pub pkcs11_id: Option<Blob>,
+    pub obj_type: Option<ObjectType>,
+    pub limit: Option<usize>,
+    pub offset: Option<usize>,
+    #[serde(flatten)]
+    pub sort: Option<SobjectSort>,
+    pub compliant_with_policies: Option<bool>,
+    #[serde(flatten)]
+    pub custom_metadata: Option<CustomMetadata>,
+    pub with_metadata: Option<bool>,
+    pub show_destroyed: bool,
+    pub show_deleted: bool,
+    pub show_value: bool,
+    pub show_pub_key: bool,
+    #[serde(default)]
+    pub filter: Option<FilterList>
+}
+
+impl UrlEncode for ListSobjectsParams {
+    fn url_encode(&self, m: &mut HashMap<String, String>) {
+        if let Some(ref v) = self.group_id {
+            m.insert("group_id".to_string(), v.to_string());
+        }
+        if let Some(ref v) = self.creator {
+            m.insert("creator".to_string(), v.to_string());
+        }
+        if let Some(ref v) = self.name {
+            m.insert("name".to_string(), v.to_string());
+        }
+        if let Some(ref v) = self.pkcs11_label {
+            m.insert("pkcs11_label".to_string(), v.to_string());
+        }
+        if let Some(ref v) = self.pkcs11_id {
+            m.insert("pkcs11_id".to_string(), v.to_string());
+        }
+        if let Some(ref v) = self.obj_type {
+            m.insert("obj_type".to_string(), v.to_string());
+        }
+        if let Some(ref v) = self.limit {
+            m.insert("limit".to_string(), v.to_string());
+        }
+        if let Some(ref v) = self.offset {
+            m.insert("offset".to_string(), v.to_string());
+        }
+        self.sort.url_encode(m);
+        if let Some(ref v) = self.compliant_with_policies {
+            m.insert("compliant_with_policies".to_string(), v.to_string());
+        }
+        self.custom_metadata.url_encode(m);
+        if let Some(ref v) = self.with_metadata {
+            m.insert("with_metadata".to_string(), v.to_string());
+        }
+        m.insert("show_destroyed".to_string(), self.show_destroyed.to_string());
+        m.insert("show_deleted".to_string(), self.show_deleted.to_string());
+        m.insert("show_value".to_string(), self.show_value.to_string());
+        m.insert("show_pub_key".to_string(), self.show_pub_key.to_string());
+        if let Some(ref v) = self.filter {
+            m.insert("filter".to_string(), v.head.encode());
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Metadata {
+    pub total_count: usize,
+    pub filtered_count: usize
 }
 
 /// Request to compute digest of a key.
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
 pub struct ObjectDigestRequest {
     pub key: SobjectDescriptor,
-    pub alg: DigestAlgorithm,
+    pub alg: DigestAlgorithm
 }
 
 /// Digest of a key.
@@ -61,7 +176,7 @@ pub struct ObjectDigestRequest {
 pub struct ObjectDigestResponse {
     #[serde(default)]
     pub kid: Option<Uuid>,
-    pub digest: Blob,
+    pub digest: Blob
 }
 
 /// Request to persist a transient key.
@@ -77,7 +192,7 @@ pub struct PersistTransientKeyRequest {
     pub description: Option<String>,
     /// User-defined metadata for the persisted key stored as key-value pairs.
     #[serde(default)]
-    pub custom_metadata: Option<HashMap<String, String>>,
+    pub custom_metadata: Option<HashMap<String,String>>,
     /// Whether the new security object should be enabled. Disabled security objects may not perform cryptographic operations.
     #[serde(default)]
     pub enabled: Option<bool>,
@@ -89,87 +204,277 @@ pub struct PersistTransientKeyRequest {
     #[serde(default)]
     pub state: Option<SobjectState>,
     /// Transient key to persist.
-    pub transient_key: Blob,
+    pub transient_key: Blob
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Default)]
-pub struct ListSobjectsParams {
-    pub group_id: Option<Uuid>,
-    pub creator: Option<Uuid>,
-    pub name: Option<String>,
-    pub limit: Option<usize>,
-    pub offset: Option<usize>,
-    #[serde(flatten)]
-    pub sort: SobjectSort,
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
+pub struct RevertRequest {
+    pub ids: Vec<Uuid>
 }
 
-impl UrlEncode for ListSobjectsParams {
-    fn url_encode(&self, m: &mut HashMap<&'static str, String>) {
-        if let Some(ref v) = self.group_id {
-            m.insert("group_id", v.to_string());
-        }
-        if let Some(ref v) = self.creator {
-            m.insert("creator", v.to_string());
-        }
-        if let Some(ref v) = self.name {
-            m.insert("name", v.to_string());
-        }
-        if let Some(ref v) = self.limit {
-            m.insert("limit", v.to_string());
-        }
-        if let Some(ref v) = self.offset {
-            m.insert("offset", v.to_string());
-        }
-        self.sort.url_encode(m);
-    }
-}
-
-#[derive(Serialize, Deserialize, Clone, Default)]
-pub struct GetSobjectParams {
-    pub view: SobjectEncoding,
-}
-
-impl UrlEncode for GetSobjectParams {
-    fn url_encode(&self, m: &mut HashMap<&'static str, String>) {
-        m.insert("view", self.view.to_string());
-    }
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "snake_case")]
+pub struct SobjectComponent {
+    pub component: Blob,
+    pub component_kcv: Option<String>,
+    pub custodian: Principal
 }
 
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum SobjectEncoding {
     Json,
-    Value,
+    Value
 }
 
+/// Request to rekey a security object
 #[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SobjectRekeyRequest {
+    pub deactivate_rotated_key: bool,
+    #[serde(flatten)]
+    pub dest: SobjectRequest
+}
+
+#[derive(Default, Debug, Serialize, Deserialize, Clone)]
+pub struct SobjectRequest {
+    #[serde(default)]
+    pub activation_date: Option<Time>,
+    #[serde(default)]
+    pub aes: Option<AesOptions>,
+    #[serde(default)]
+    pub custom_metadata: Option<HashMap<String,String>>,
+    #[serde(default)]
+    pub deactivation_date: Option<Time>,
+    #[serde(default)]
+    pub des: Option<DesOptions>,
+    #[serde(default)]
+    pub des3: Option<Des3Options>,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub deterministic_signatures: Option<bool>,
+    #[serde(default)]
+    pub dsa: Option<DsaOptions>,
+    #[serde(default)]
+    pub elliptic_curve: Option<EllipticCurve>,
+    #[serde(default)]
+    pub enabled: Option<bool>,
+    #[serde(default)]
+    pub fpe: Option<FpeOptions>,
+    #[serde(default)]
+    pub kcv: Option<String>,
+    #[serde(default)]
+    pub key_ops: Option<KeyOperations>,
+    #[serde(default)]
+    pub key_size: Option<u32>,
+    #[serde(default)]
+    pub links: Option<KeyLinks>,
+    #[serde(default)]
+    pub lms: Option<LmsOptions>,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub obj_type: Option<ObjectType>,
+    #[serde(default)]
+    pub pub_exponent: Option<u32>,
+    #[serde(default)]
+    pub publish_public_key: Option<PublishPublicKeyConfig>,
+    #[serde(default)]
+    pub rotation_policy: Option<RotationPolicy>,
+    #[serde(default)]
+    pub rsa: Option<RsaOptions>,
+    #[serde(default)]
+    pub seed: Option<SeedOptions>,
+    #[serde(default)]
+    pub state: Option<SobjectState>,
+    #[serde(default)]
+    pub transient: Option<bool>,
+    #[serde(default)]
+    pub value: Option<Blob>,
+    #[serde(default)]
+    pub group_id: Option<Uuid>
+}
+
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
 pub enum SobjectSort {
-    ByKid { order: Order, start: Option<Uuid> },
-    ByName { order: Order, start: Option<String> },
+    ByKid {
+        order: Order,
+        start: Option<Uuid>
+    },
+    ByName {
+        order: Order,
+        start: Option<String>
+    }
 }
 
 impl UrlEncode for SobjectSort {
-    fn url_encode(&self, m: &mut HashMap<&'static str, String>) {
+    fn url_encode(&self, m: &mut HashMap<String, String>) {
         match *self {
-            SobjectSort::ByKid {
-                ref order,
-                ref start,
-            } => {
-                m.insert("sort", format!("kid:{}", order));
+            SobjectSort::ByKid{ ref order, ref start } => {
+                m.insert("sort".to_string(), format!("kid:{}", order));
                 if let Some(v) = start {
-                    m.insert("start", v.to_string());
+                    m.insert("start".to_string(), v.to_string());
                 }
             }
-            SobjectSort::ByName {
-                ref order,
-                ref start,
-            } => {
-                m.insert("sort", format!("name:{}", order));
+            SobjectSort::ByName{ ref order, ref start } => {
+                m.insert("sort".to_string(), format!("name:{}", order));
                 if let Some(v) = start {
-                    m.insert("start", v.to_string());
+                    m.insert("start".to_string(), v.to_string());
                 }
             }
         }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
+pub enum SplittingMethod {
+    XOR
+}
+
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
+pub struct UnwrapKeyParams {
+    pub key: SobjectDescriptor,
+    pub alg: Algorithm,
+    /// Mode is required for symmetric algorithms.
+    #[serde(default)]
+    pub mode: Option<CryptMode>,
+    /// Initialization vector is required for symmetric algorithms.
+    #[serde(default)]
+    pub iv: Option<Blob>,
+    /// Authenticated data is only applicable if mode is GCM.
+    #[serde(default)]
+    pub ad: Option<Blob>,
+    /// Tag is required if mode is GCM.
+    #[serde(default)]
+    pub tag: Option<Blob>
+}
+
+/// Verify KCV of a key
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct VerifyKcvRequest {
+    pub kcv: String,
+    pub value: Blob,
+    pub obj_type: ObjectType
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct VerifyKcvResponse {
+    pub verified: bool
+}
+
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
+pub struct WrapKeyParams {
+    /// The wrapping key.
+    pub key: SobjectDescriptor,
+    pub alg: Algorithm,
+    /// Mode is required for symmetric algorithms.
+    #[serde(default)]
+    pub mode: Option<CryptMode>,
+    #[serde(default)]
+    pub iv: Option<Blob>,
+    /// Authenticated data is only applicable if mode is GCM.
+    #[serde(default)]
+    pub ad: Option<Blob>,
+    /// Tag length is required when mode is GCM.
+    #[serde(default)]
+    pub tag_len: Option<usize>
+}
+
+pub struct OperationActivateSobject;
+#[allow(unused)]
+impl Operation for OperationActivateSobject {
+    type PathParams = (Uuid,);
+    type QueryParams = ();
+    type Body = ();
+    type Output = ();
+
+    fn method() -> Method {
+        Method::POST
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/crypto/v1/keys/{id}/activate", id = p.0)
+    }
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+
+impl SdkmsClient {
+    pub fn activate_sobject(&self, id: &Uuid) -> Result<()> {
+        self.execute::<OperationActivateSobject>(&(), (id,), None)
+    }
+}
+
+pub struct OperationBatchSign;
+#[allow(unused)]
+impl Operation for OperationBatchSign {
+    type PathParams = ();
+    type QueryParams = ();
+    type Body = Vec<SignRequest>;
+    type Output = Vec<BatchResponseItem<SignResponse>>;
+
+    fn method() -> Method {
+        Method::POST
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/crypto/v1/keys/batch/sign")
+    }
+}
+
+impl SdkmsClient {
+    pub fn batch_sign(&self, req: &Vec<SignRequest>) -> Result<Vec<BatchResponseItem<SignResponse>>> {
+        self.execute::<OperationBatchSign>(req, (), None)
+    }
+    pub fn request_approval_to_batch_sign(
+        &self, req: &Vec<SignRequest>,
+        description: Option<String>) -> Result<PendingApproval<OperationBatchSign>> {
+        self.request_approval::<OperationBatchSign>(req, (), None, description)
+    }
+}
+
+pub struct OperationBatchVerify;
+#[allow(unused)]
+impl Operation for OperationBatchVerify {
+    type PathParams = ();
+    type QueryParams = ();
+    type Body = Vec<VerifyRequest>;
+    type Output = Vec<BatchResponseItem<VerifyResponse>>;
+
+    fn method() -> Method {
+        Method::POST
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/crypto/v1/keys/batch/verify")
+    }
+}
+
+impl SdkmsClient {
+    pub fn batch_verify(&self, req: &Vec<VerifyRequest>) -> Result<Vec<BatchResponseItem<VerifyResponse>>> {
+        self.execute::<OperationBatchVerify>(req, (), None)
+    }
+}
+
+pub struct OperationCopySobject;
+#[allow(unused)]
+impl Operation for OperationCopySobject {
+    type PathParams = ();
+    type QueryParams = ();
+    type Body = CopySobjectRequest;
+    type Output = Sobject;
+
+    fn method() -> Method {
+        Method::POST
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/crypto/v1/keys/copy")
+    }
+}
+
+impl SdkmsClient {
+    pub fn copy_sobject(&self, req: &CopySobjectRequest) -> Result<Sobject> {
+        self.execute::<OperationCopySobject>(req, (), None)
+    }
+    pub fn request_approval_to_copy_sobject(
+        &self, req: &CopySobjectRequest,
+        description: Option<String>) -> Result<PendingApproval<OperationCopySobject>> {
+        self.request_approval::<OperationCopySobject>(req, (), None, description)
     }
 }
 
@@ -195,58 +500,6 @@ impl SdkmsClient {
     }
 }
 
-pub struct OperationImportSobject;
-#[allow(unused)]
-impl Operation for OperationImportSobject {
-    type PathParams = ();
-    type QueryParams = ();
-    type Body = SobjectRequest;
-    type Output = Sobject;
-
-    fn method() -> Method {
-        Method::PUT
-    }
-    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
-        format!("/crypto/v1/keys")
-    }
-}
-
-impl SdkmsClient {
-    pub fn import_sobject(&self, req: &SobjectRequest) -> Result<Sobject> {
-        self.execute::<OperationImportSobject>(req, (), None)
-    }
-}
-
-pub struct OperationUpdateSobject;
-#[allow(unused)]
-impl Operation for OperationUpdateSobject {
-    type PathParams = (Uuid,);
-    type QueryParams = ();
-    type Body = SobjectRequest;
-    type Output = Sobject;
-
-    fn method() -> Method {
-        Method::PATCH
-    }
-    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
-        format!("/crypto/v1/keys/{id}", id = p.0)
-    }
-}
-
-impl SdkmsClient {
-    pub fn update_sobject(&self, id: &Uuid, req: &SobjectRequest) -> Result<Sobject> {
-        self.execute::<OperationUpdateSobject>(req, (id,), None)
-    }
-    pub fn request_approval_to_update_sobject(
-        &self,
-        id: &Uuid,
-        req: &SobjectRequest,
-        description: Option<String>,
-    ) -> Result<PendingApproval<OperationUpdateSobject>> {
-        self.request_approval::<OperationUpdateSobject>(req, (id,), None, description)
-    }
-}
-
 pub struct OperationDeleteSobject;
 #[allow(unused)]
 impl Operation for OperationDeleteSobject {
@@ -261,126 +514,43 @@ impl Operation for OperationDeleteSobject {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/crypto/v1/keys/{id}", id = p.0)
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
-        None
-    }
-}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
 
 impl SdkmsClient {
     pub fn delete_sobject(&self, id: &Uuid) -> Result<()> {
         self.execute::<OperationDeleteSobject>(&(), (id,), None)
     }
     pub fn request_approval_to_delete_sobject(
-        &self,
-        id: &Uuid,
-        description: Option<String>,
-    ) -> Result<PendingApproval<OperationDeleteSobject>> {
+        &self, id: &Uuid,
+        description: Option<String>) -> Result<PendingApproval<OperationDeleteSobject>> {
         self.request_approval::<OperationDeleteSobject>(&(), (id,), None, description)
     }
 }
 
-pub struct OperationListSobjects;
+pub struct OperationDestroySobject;
 #[allow(unused)]
-impl Operation for OperationListSobjects {
-    type PathParams = ();
-    type QueryParams = ListSobjectsParams;
-    type Body = ();
-    type Output = Vec<Sobject>;
-
-    fn method() -> Method {
-        Method::GET
-    }
-    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
-        format!("/crypto/v1/keys?{q}", q = q.encode())
-    }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
-        None
-    }
-}
-
-impl SdkmsClient {
-    pub fn list_sobjects(&self, query_params: Option<&ListSobjectsParams>) -> Result<Vec<Sobject>> {
-        self.execute::<OperationListSobjects>(&(), (), query_params)
-    }
-}
-
-pub struct OperationGetSobject;
-#[allow(unused)]
-impl Operation for OperationGetSobject {
-    type PathParams = ();
-    type QueryParams = GetSobjectParams;
-    type Body = SobjectDescriptor;
-    type Output = Sobject;
-
-    fn method() -> Method {
-        Method::POST
-    }
-    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
-        format!("/crypto/v1/keys/info?{q}", q = q.encode())
-    }
-}
-
-impl SdkmsClient {
-    pub fn get_sobject(
-        &self,
-        query_params: Option<&GetSobjectParams>,
-        req: &SobjectDescriptor,
-    ) -> Result<Sobject> {
-        self.execute::<OperationGetSobject>(req, (), query_params)
-    }
-}
-
-pub struct OperationRemovePrivate;
-#[allow(unused)]
-impl Operation for OperationRemovePrivate {
+impl Operation for OperationDestroySobject {
     type PathParams = (Uuid,);
     type QueryParams = ();
     type Body = ();
     type Output = ();
 
     fn method() -> Method {
-        Method::DELETE
-    }
-    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
-        format!("/crypto/v1/keys/{id}/private", id = p.0)
-    }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
-        None
-    }
-}
-
-impl SdkmsClient {
-    pub fn remove_private(&self, id: &Uuid) -> Result<()> {
-        self.execute::<OperationRemovePrivate>(&(), (id,), None)
-    }
-}
-
-pub struct OperationExportSobject;
-#[allow(unused)]
-impl Operation for OperationExportSobject {
-    type PathParams = ();
-    type QueryParams = ();
-    type Body = SobjectDescriptor;
-    type Output = Sobject;
-
-    fn method() -> Method {
         Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
-        format!("/crypto/v1/keys/export")
+        format!("/crypto/v1/keys/{id}/destroy", id = p.0)
     }
-}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
 
 impl SdkmsClient {
-    pub fn export_sobject(&self, req: &SobjectDescriptor) -> Result<Sobject> {
-        self.execute::<OperationExportSobject>(req, (), None)
+    pub fn destroy_sobject(&self, id: &Uuid) -> Result<()> {
+        self.execute::<OperationDestroySobject>(&(), (id,), None)
     }
-    pub fn request_approval_to_export_sobject(
-        &self,
-        req: &SobjectDescriptor,
-        description: Option<String>,
-    ) -> Result<PendingApproval<OperationExportSobject>> {
-        self.request_approval::<OperationExportSobject>(req, (), None, description)
+    pub fn request_approval_to_destroy_sobject(
+        &self, id: &Uuid,
+        description: Option<String>) -> Result<PendingApproval<OperationDestroySobject>> {
+        self.request_approval::<OperationDestroySobject>(&(), (id,), None, description)
     }
 }
 
@@ -406,6 +576,197 @@ impl SdkmsClient {
     }
 }
 
+pub struct OperationExportSobject;
+#[allow(unused)]
+impl Operation for OperationExportSobject {
+    type PathParams = ();
+    type QueryParams = ();
+    type Body = SobjectDescriptor;
+    type Output = Sobject;
+
+    fn method() -> Method {
+        Method::POST
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/crypto/v1/keys/export")
+    }
+}
+
+impl SdkmsClient {
+    pub fn export_sobject(&self, req: &SobjectDescriptor) -> Result<Sobject> {
+        self.execute::<OperationExportSobject>(req, (), None)
+    }
+    pub fn request_approval_to_export_sobject(
+        &self, req: &SobjectDescriptor,
+        description: Option<String>) -> Result<PendingApproval<OperationExportSobject>> {
+        self.request_approval::<OperationExportSobject>(req, (), None, description)
+    }
+}
+
+pub struct OperationExportSobjectComponents;
+#[allow(unused)]
+impl Operation for OperationExportSobjectComponents {
+    type PathParams = ();
+    type QueryParams = ();
+    type Body = ExportSobjectComponentsRequest;
+    type Output = ExportComponentsResponse;
+
+    fn method() -> Method {
+        Method::POST
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/crypto/v1/keys/components/export")
+    }
+}
+
+impl SdkmsClient {
+    pub fn export_sobject_components(&self, req: &ExportSobjectComponentsRequest) -> Result<ExportComponentsResponse> {
+        self.execute::<OperationExportSobjectComponents>(req, (), None)
+    }
+    pub fn request_approval_to_export_sobject_components(
+        &self, req: &ExportSobjectComponentsRequest,
+        description: Option<String>) -> Result<PendingApproval<OperationExportSobjectComponents>> {
+        self.request_approval::<OperationExportSobjectComponents>(req, (), None, description)
+    }
+}
+
+pub struct OperationGetKcv;
+#[allow(unused)]
+impl Operation for OperationGetKcv {
+    type PathParams = ();
+    type QueryParams = ();
+    type Body = SobjectDescriptor;
+    type Output = KeyCheckValueResponse;
+
+    fn method() -> Method {
+        Method::POST
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/crypto/v1/keys/kcv")
+    }
+}
+
+impl SdkmsClient {
+    pub fn get_kcv(&self, req: &SobjectDescriptor) -> Result<KeyCheckValueResponse> {
+        self.execute::<OperationGetKcv>(req, (), None)
+    }
+}
+
+pub struct OperationGetPubkey;
+#[allow(unused)]
+impl Operation for OperationGetPubkey {
+    type PathParams = (Uuid, String,);
+    type QueryParams = ();
+    type Body = ();
+    type Output = HashMap<String,Blob>;
+
+    fn method() -> Method {
+        Method::GET
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/crypto/v1/pubkey/{id}/{name}", id = p.0, name = p.1)
+    }
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+
+impl SdkmsClient {
+    pub fn get_pubkey(&self, id: &Uuid, name: &String) -> Result<HashMap<String,Blob>> {
+        self.execute::<OperationGetPubkey>(&(), (id, name,), None)
+    }
+}
+
+pub struct OperationGetSobject;
+#[allow(unused)]
+impl Operation for OperationGetSobject {
+    type PathParams = ();
+    type QueryParams = GetSobjectParams;
+    type Body = SobjectDescriptor;
+    type Output = Sobject;
+
+    fn method() -> Method {
+        Method::POST
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/crypto/v1/keys/info?{q}", q = q.encode())
+    }
+}
+
+impl SdkmsClient {
+    pub fn get_sobject(&self, query_params: Option<&GetSobjectParams>, req: &SobjectDescriptor) -> Result<Sobject> {
+        self.execute::<OperationGetSobject>(req, (), query_params)
+    }
+}
+
+pub struct OperationImportSobject;
+#[allow(unused)]
+impl Operation for OperationImportSobject {
+    type PathParams = ();
+    type QueryParams = ();
+    type Body = SobjectRequest;
+    type Output = Sobject;
+
+    fn method() -> Method {
+        Method::PUT
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/crypto/v1/keys")
+    }
+}
+
+impl SdkmsClient {
+    pub fn import_sobject(&self, req: &SobjectRequest) -> Result<Sobject> {
+        self.execute::<OperationImportSobject>(req, (), None)
+    }
+}
+
+pub struct OperationImportSobjectByComponents;
+#[allow(unused)]
+impl Operation for OperationImportSobjectByComponents {
+    type PathParams = ();
+    type QueryParams = ();
+    type Body = ImportSobjectComponentsRequest;
+    type Output = Sobject;
+
+    fn method() -> Method {
+        Method::POST
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/crypto/v1/keys/components/import")
+    }
+}
+
+impl SdkmsClient {
+    pub fn import_sobject_by_components(&self, req: &ImportSobjectComponentsRequest) -> Result<Sobject> {
+        self.execute::<OperationImportSobjectByComponents>(req, (), None)
+    }
+    pub fn request_approval_to_import_sobject_by_components(
+        &self, req: &ImportSobjectComponentsRequest,
+        description: Option<String>) -> Result<PendingApproval<OperationImportSobjectByComponents>> {
+        self.request_approval::<OperationImportSobjectByComponents>(req, (), None, description)
+    }
+}
+
+pub struct OperationListSobjects;
+#[allow(unused)]
+impl Operation for OperationListSobjects {
+    type PathParams = ();
+    type QueryParams = ListSobjectsParams;
+    type Body = ();
+    type Output = GetAllResponse;
+
+    fn method() -> Method {
+        Method::GET
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/crypto/v1/keys?{q}", q = q.encode())
+    }
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+
+impl SdkmsClient {
+    pub fn list_sobjects(&self, query_params: Option<&ListSobjectsParams>) -> Result<GetAllResponse> {
+        self.execute::<OperationListSobjects>(&(), (), query_params)
+    }
+}
+
 pub struct OperationPersistTransientKey;
 #[allow(unused)]
 impl Operation for OperationPersistTransientKey {
@@ -428,50 +789,57 @@ impl SdkmsClient {
     }
 }
 
-pub struct OperationRotateSobject;
+pub struct OperationRemovePrivate;
 #[allow(unused)]
-impl Operation for OperationRotateSobject {
-    type PathParams = ();
-    type QueryParams = ();
-    type Body = SobjectRequest;
-    type Output = Sobject;
-
-    fn method() -> Method {
-        Method::POST
-    }
-    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
-        format!("/crypto/v1/keys/rekey")
-    }
-}
-
-impl SdkmsClient {
-    pub fn rotate_sobject(&self, req: &SobjectRequest) -> Result<Sobject> {
-        self.execute::<OperationRotateSobject>(req, (), None)
-    }
-}
-
-pub struct OperationActivateSobject;
-#[allow(unused)]
-impl Operation for OperationActivateSobject {
+impl Operation for OperationRemovePrivate {
     type PathParams = (Uuid,);
     type QueryParams = ();
     type Body = ();
     type Output = ();
 
     fn method() -> Method {
-        Method::POST
+        Method::DELETE
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
-        format!("/crypto/v1/keys/{id}/activate", id = p.0)
+        format!("/crypto/v1/keys/{id}/private", id = p.0)
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
-        None
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+
+impl SdkmsClient {
+    pub fn remove_private(&self, id: &Uuid) -> Result<()> {
+        self.execute::<OperationRemovePrivate>(&(), (id,), None)
+    }
+    pub fn request_approval_to_remove_private(
+        &self, id: &Uuid,
+        description: Option<String>) -> Result<PendingApproval<OperationRemovePrivate>> {
+        self.request_approval::<OperationRemovePrivate>(&(), (id,), None, description)
+    }
+}
+
+pub struct OperationRevertPrevKeyOp;
+#[allow(unused)]
+impl Operation for OperationRevertPrevKeyOp {
+    type PathParams = (Uuid,);
+    type QueryParams = ();
+    type Body = RevertRequest;
+    type Output = ();
+
+    fn method() -> Method {
+        Method::PUT
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/crypto/v1/keys/{id}/revert", id = p.0)
     }
 }
 
 impl SdkmsClient {
-    pub fn activate_sobject(&self, id: &Uuid) -> Result<()> {
-        self.execute::<OperationActivateSobject>(&(), (id,), None)
+    pub fn revert_prev_key_op(&self, id: &Uuid, req: &RevertRequest) -> Result<()> {
+        self.execute::<OperationRevertPrevKeyOp>(req, (id,), None)
+    }
+    pub fn request_approval_to_revert_prev_key_op(
+        &self, id: &Uuid, req: &RevertRequest,
+        description: Option<String>) -> Result<PendingApproval<OperationRevertPrevKeyOp>> {
+        self.request_approval::<OperationRevertPrevKeyOp>(req, (id,), None, description)
     }
 }
 
@@ -495,61 +863,86 @@ impl SdkmsClient {
     pub fn revoke_sobject(&self, id: &Uuid, req: &RevocationReason) -> Result<()> {
         self.execute::<OperationRevokeSobject>(req, (id,), None)
     }
+    pub fn request_approval_to_revoke_sobject(
+        &self, id: &Uuid, req: &RevocationReason,
+        description: Option<String>) -> Result<PendingApproval<OperationRevokeSobject>> {
+        self.request_approval::<OperationRevokeSobject>(req, (id,), None, description)
+    }
 }
 
-pub struct OperationBatchSign;
+pub struct OperationRotateSobject;
 #[allow(unused)]
-impl Operation for OperationBatchSign {
+impl Operation for OperationRotateSobject {
     type PathParams = ();
     type QueryParams = ();
-    type Body = Vec<SignRequest>;
-    type Output = Vec<BatchResponseItem<SignResponse>>;
+    type Body = SobjectRekeyRequest;
+    type Output = Sobject;
 
     fn method() -> Method {
         Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
-        format!("/crypto/v1/keys/batch/sign")
+        format!("/crypto/v1/keys/rekey")
     }
 }
 
 impl SdkmsClient {
-    pub fn batch_sign(
-        &self,
-        req: &Vec<SignRequest>,
-    ) -> Result<Vec<BatchResponseItem<SignResponse>>> {
-        self.execute::<OperationBatchSign>(req, (), None)
+    pub fn rotate_sobject(&self, req: &SobjectRekeyRequest) -> Result<Sobject> {
+        self.execute::<OperationRotateSobject>(req, (), None)
     }
-    pub fn request_approval_to_batch_sign(
-        &self,
-        req: &Vec<SignRequest>,
-        description: Option<String>,
-    ) -> Result<PendingApproval<OperationBatchSign>> {
-        self.request_approval::<OperationBatchSign>(req, (), None, description)
+    pub fn request_approval_to_rotate_sobject(
+        &self, req: &SobjectRekeyRequest,
+        description: Option<String>) -> Result<PendingApproval<OperationRotateSobject>> {
+        self.request_approval::<OperationRotateSobject>(req, (), None, description)
     }
 }
 
-pub struct OperationBatchVerify;
+pub struct OperationUpdateSobject;
 #[allow(unused)]
-impl Operation for OperationBatchVerify {
+impl Operation for OperationUpdateSobject {
+    type PathParams = (Uuid,);
+    type QueryParams = ();
+    type Body = SobjectRequest;
+    type Output = Sobject;
+
+    fn method() -> Method {
+        Method::PATCH
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/crypto/v1/keys/{id}", id = p.0)
+    }
+}
+
+impl SdkmsClient {
+    pub fn update_sobject(&self, id: &Uuid, req: &SobjectRequest) -> Result<Sobject> {
+        self.execute::<OperationUpdateSobject>(req, (id,), None)
+    }
+    pub fn request_approval_to_update_sobject(
+        &self, id: &Uuid, req: &SobjectRequest,
+        description: Option<String>) -> Result<PendingApproval<OperationUpdateSobject>> {
+        self.request_approval::<OperationUpdateSobject>(req, (id,), None, description)
+    }
+}
+
+pub struct OperationVerifyKcv;
+#[allow(unused)]
+impl Operation for OperationVerifyKcv {
     type PathParams = ();
     type QueryParams = ();
-    type Body = Vec<VerifyRequest>;
-    type Output = Vec<BatchResponseItem<VerifyResponse>>;
+    type Body = VerifyKcvRequest;
+    type Output = VerifyKcvResponse;
 
     fn method() -> Method {
         Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
-        format!("/crypto/v1/keys/batch/verify")
+        format!("/crypto/v1/keys/kcv/verify")
     }
 }
 
 impl SdkmsClient {
-    pub fn batch_verify(
-        &self,
-        req: &Vec<VerifyRequest>,
-    ) -> Result<Vec<BatchResponseItem<VerifyResponse>>> {
-        self.execute::<OperationBatchVerify>(req, (), None)
+    pub fn verify_kcv(&self, req: &VerifyKcvRequest) -> Result<VerifyKcvResponse> {
+        self.execute::<OperationVerifyKcv>(req, (), None)
     }
 }
+

--- a/src/generated/logs_generated.rs
+++ b/src/generated/logs_generated.rs
@@ -1,0 +1,108 @@
+/* Copyright (c) Fortanix, Inc.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use super::*;
+
+#[derive(Debug, Eq, PartialEq, Copy, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum ActionType {
+    Administrative,
+    Auth,
+    CryptoOperation,
+    RunPlugin,
+    Custom,
+    Other
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct EsAuditLogOuter {
+    pub _id: String,
+    pub _source: EsAuditLog
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct EsAuditQueryResponse {
+    pub hits: Vec<EsAuditLogOuter>
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+pub struct LogsParams {
+    /// The input `size` value can't be greater than 1000. If a higher
+    /// value is specifed, only 1000 results are returned.
+    pub size: Option<u32>,
+    pub from: Option<u32>,
+    pub range_from: Option<u64>,
+    pub range_to: Option<u64>,
+    pub action_type: Option<Vec<ActionType>>,
+    pub actor_type: Option<Vec<String>>,
+    pub actor_id: Option<Uuid>,
+    pub object_id: Option<Uuid>,
+    pub severity: Option<Vec<SeverityLevel>>
+}
+
+impl UrlEncode for LogsParams {
+    fn url_encode(&self, m: &mut HashMap<String, String>) {
+        if let Some(ref v) = self.size {
+            m.insert("size".to_string(), v.to_string());
+        }
+        if let Some(ref v) = self.from {
+            m.insert("from".to_string(), v.to_string());
+        }
+        if let Some(ref v) = self.range_from {
+            m.insert("range_from".to_string(), v.to_string());
+        }
+        if let Some(ref v) = self.range_to {
+            m.insert("range_to".to_string(), v.to_string());
+        }
+        if let Some(ref v) = self.action_type {
+            m.insert("action_type".to_string(), v.to_string());
+        }
+        if let Some(ref v) = self.actor_type {
+            m.insert("actor_type".to_string(), v.to_string());
+        }
+        if let Some(ref v) = self.actor_id {
+            m.insert("actor_id".to_string(), v.to_string());
+        }
+        if let Some(ref v) = self.object_id {
+            m.insert("object_id".to_string(), v.to_string());
+        }
+        if let Some(ref v) = self.severity {
+            m.insert("severity".to_string(), v.to_string());
+        }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Copy, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum SeverityLevel {
+    Info,
+    Warning,
+    Error,
+    Critical
+}
+
+pub struct OperationGetAllLogs;
+#[allow(unused)]
+impl Operation for OperationGetAllLogs {
+    type PathParams = ();
+    type QueryParams = LogsParams;
+    type Body = ();
+    type Output = EsAuditQueryResponse;
+
+    fn method() -> Method {
+        Method::GET
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/sys/v1/logs?{q}", q = q.encode())
+    }
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+
+impl SdkmsClient {
+    pub fn get_all_logs(&self, query_params: Option<&LogsParams>) -> Result<EsAuditQueryResponse> {
+        self.execute::<OperationGetAllLogs>(&(), (), query_params)
+    }
+}
+

--- a/src/generated/marketplace_generated.rs
+++ b/src/generated/marketplace_generated.rs
@@ -1,0 +1,47 @@
+/* Copyright (c) Fortanix, Inc.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use super::*;
+
+#[derive(Serialize, Deserialize, Clone, Default)]
+pub struct GetMarketplaceParams {
+    pub repo_url: String
+}
+
+impl UrlEncode for GetMarketplaceParams {
+    fn url_encode(&self, m: &mut HashMap<String, String>) {
+        m.insert("repo_url".to_string(), self.repo_url.to_string());
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct MarketplacePlugin {
+    pub name: String,
+    pub versions: HashMap<PluginVersion,Option<String>>
+}
+
+pub struct OperationGetMarketplace;
+#[allow(unused)]
+impl Operation for OperationGetMarketplace {
+    type PathParams = ();
+    type QueryParams = GetMarketplaceParams;
+    type Body = ();
+    type Output = Vec<MarketplacePlugin>;
+
+    fn method() -> Method {
+        Method::GET
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/sys/v1/marketplace?{q}", q = q.encode())
+    }
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+
+impl SdkmsClient {
+    pub fn get_marketplace(&self, query_params: Option<&GetMarketplaceParams>) -> Result<Vec<MarketplacePlugin>> {
+        self.execute::<OperationGetMarketplace>(&(), (), query_params)
+    }
+}
+

--- a/src/generated/misc_generated.rs
+++ b/src/generated/misc_generated.rs
@@ -1,0 +1,168 @@
+/* Copyright (c) Fortanix, Inc.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use super::*;
+
+#[derive(Serialize, Deserialize, Clone, Default)]
+pub struct HealthParams {
+    pub consistency: Option<String>,
+    pub check_queues: bool
+}
+
+impl UrlEncode for HealthParams {
+    fn url_encode(&self, m: &mut HashMap<String, String>) {
+        if let Some(ref v) = self.consistency {
+            m.insert("consistency".to_string(), v.to_string());
+        }
+        m.insert("check_queues".to_string(), self.check_queues.to_string());
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Clone)]
+#[serde(untagged)]
+pub enum LdapPrincipal {
+    Unresolved {
+        email: String
+    },
+    Resolved {
+        dn: String
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
+pub struct LdapSearchFilter {
+    pub name: String,
+    pub value: String
+}
+
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
+pub struct LdapSearchRequest {
+    pub base_dn: Option<String>,
+    pub filters: Vec<LdapSearchFilter>,
+    pub object_class: Option<String>,
+    pub scope: LdapSearchScope
+}
+
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
+pub struct LdapSearchResultEntry {
+    pub distinguished_name: String,
+    pub ldap_object_id: Uuid,
+    pub common_name: Vec<String>,
+    pub description: Vec<String>,
+    pub object_class: Vec<String>,
+    pub mail: Option<String>,
+    pub user_principal_name: Option<String>
+}
+
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub enum LdapSearchScope {
+    SingleLevel,
+    WholeSubtree
+}
+
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
+pub struct LdapTestCredentials {
+    #[serde(flatten)]
+    pub id: LdapPrincipal,
+    pub password: String,
+    pub account_role: Option<AccountRole>
+}
+
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
+pub struct LdapTestRequest {
+    pub ldap: AuthConfigLdap,
+    pub test_credentials: Option<LdapTestCredentials>
+}
+
+pub struct OperationGetHealth;
+#[allow(unused)]
+impl Operation for OperationGetHealth {
+    type PathParams = ();
+    type QueryParams = HealthParams;
+    type Body = ();
+    type Output = ();
+
+    fn method() -> Method {
+        Method::GET
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/sys/v1/health?{q}", q = q.encode())
+    }
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+
+impl SdkmsClient {
+    pub fn get_health(&self, query_params: Option<&HealthParams>) -> Result<()> {
+        self.execute::<OperationGetHealth>(&(), (), query_params)
+    }
+}
+
+pub struct OperationLdapSearch;
+#[allow(unused)]
+impl Operation for OperationLdapSearch {
+    type PathParams = (Uuid,);
+    type QueryParams = ();
+    type Body = LdapSearchRequest;
+    type Output = Vec<LdapSearchResultEntry>;
+
+    fn method() -> Method {
+        Method::POST
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/sys/v1/ldap/search/{id}", id = p.0)
+    }
+}
+
+impl SdkmsClient {
+    pub fn ldap_search(&self, id: &Uuid, req: &LdapSearchRequest) -> Result<Vec<LdapSearchResultEntry>> {
+        self.execute::<OperationLdapSearch>(req, (id,), None)
+    }
+}
+
+pub struct OperationSamlSpMetadata;
+#[allow(unused)]
+impl Operation for OperationSamlSpMetadata {
+    type PathParams = ();
+    type QueryParams = ();
+    type Body = ();
+    type Output = Vec<u8>;
+
+    fn method() -> Method {
+        Method::GET
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/saml/metadata.xml")
+    }
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+
+impl SdkmsClient {
+    pub fn saml_sp_metadata(&self) -> Result<Vec<u8>> {
+        self.execute::<OperationSamlSpMetadata>(&(), (), None)
+    }
+}
+
+pub struct OperationTestLdapConfig;
+#[allow(unused)]
+impl Operation for OperationTestLdapConfig {
+    type PathParams = ();
+    type QueryParams = ();
+    type Body = LdapTestRequest;
+    type Output = ();
+
+    fn method() -> Method {
+        Method::POST
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/sys/v1/ldap/test")
+    }
+}
+
+impl SdkmsClient {
+    pub fn test_ldap_config(&self, req: &LdapTestRequest) -> Result<()> {
+        self.execute::<OperationTestLdapConfig>(req, (), None)
+    }
+}
+

--- a/src/generated/mod.rs
+++ b/src/generated/mod.rs
@@ -5,12 +5,15 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use crate::api_model::*;
-use crate::client::{PendingApproval, Result, SdkmsClient};
+use crate::client::*;
 use crate::operations::*;
 use simple_hyper_client::Method;
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 use uuid::Uuid;
+use serde::{Deserialize, Serialize, Deserializer};
+use std::net::IpAddr;
+use strum::{EnumIter};
 
 mod accounts_generated;
 mod approval_requests_generated;
@@ -71,6 +74,7 @@ impl Default for RsaOptions {
             public_exponent: None,
             encryption_policy: Vec::new(),
             signature_policy: Vec::new(),
+            minimum_key_length: None,
         }
     }
 }

--- a/src/generated/mod.rs
+++ b/src/generated/mod.rs
@@ -11,7 +11,7 @@ use simple_hyper_client::Method;
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 use uuid::Uuid;
-use serde::{Deserialize, Serialize, Deserializer};
+use serde::{Deserialize, Serialize};
 use std::net::IpAddr;
 use strum::{EnumIter};
 

--- a/src/generated/mod.rs
+++ b/src/generated/mod.rs
@@ -7,13 +7,13 @@
 use crate::api_model::*;
 use crate::client::*;
 use crate::operations::*;
+use serde::{Deserialize, Serialize};
 use simple_hyper_client::Method;
 use std::collections::{HashMap, HashSet};
 use std::fmt;
-use uuid::Uuid;
-use serde::{Deserialize, Serialize};
 use std::net::IpAddr;
-use strum::{EnumIter};
+use strum::EnumIter;
+use uuid::Uuid;
 
 mod accounts_generated;
 mod approval_requests_generated;
@@ -79,6 +79,37 @@ impl Default for RsaOptions {
     }
 }
 
+impl ToString for AppRole {
+    fn to_string(&self) -> String {
+        match *self {
+            AppRole::Admin => "admin".to_string(),
+            AppRole::Crypto => "app".to_string(),
+        }
+    }
+}
+
+impl ToString for ObjectType {
+    fn to_string(&self) -> String {
+        match *self {
+            ObjectType::Aes => "AES".to_string(),
+            ObjectType::Des => "DES".to_string(),
+            ObjectType::Des3 => "DES3".to_string(),
+            ObjectType::Rsa => "RSA".to_string(),
+            ObjectType::Dsa => "DSA".to_string(),
+            ObjectType::Ec => "EC".to_string(),
+            ObjectType::Opaque => "OPAQUE".to_string(),
+            ObjectType::Hmac => "HMAC".to_string(),
+            ObjectType::Secret => "SECRET".to_string(),
+            ObjectType::Seed => "SEED".to_string(),
+            ObjectType::Round5Beta => "ROUND5BETA".to_string(),
+            ObjectType::LedaBeta => "LEDABETA".to_string(),
+            ObjectType::Lms => "LMS".to_string(),
+            ObjectType::Certificate => "CERTIFICATE".to_string(),
+            ObjectType::Pbe => "PBE".to_string(),
+        }
+    }
+}
+
 impl fmt::Display for SobjectEncoding {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
@@ -132,5 +163,17 @@ impl Default for UserSort {
             order: Order::Ascending,
             start: None,
         }
+    }
+}
+
+impl Default for AppRole {
+    fn default() -> Self {
+        AppRole::Crypto
+    }
+}
+
+impl Default for SubscriptionType {
+    fn default() -> SubscriptionType {
+        SubscriptionType::Trial { expires_at: None }
     }
 }

--- a/src/generated/plugins_generated.rs
+++ b/src/generated/plugins_generated.rs
@@ -10,7 +10,7 @@ use super::*;
 #[derive(Debug, Eq, PartialEq, Copy, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum Language {
-    Lua
+    Lua,
 }
 
 #[derive(Serialize, Deserialize, Clone, Default)]
@@ -19,7 +19,7 @@ pub struct ListPluginsParams {
     pub limit: Option<usize>,
     pub offset: Option<usize>,
     #[serde(flatten)]
-    pub sort: PluginSort
+    pub sort: PluginSort,
 }
 
 impl UrlEncode for ListPluginsParams {
@@ -54,7 +54,7 @@ pub struct Plugin {
     pub plugin_id: Uuid,
     pub plugin_type: PluginType,
     pub source: PluginSource,
-    pub groups: HashSet<Uuid>
+    pub groups: HashSet<Uuid>,
 }
 
 #[derive(Default, Debug, Serialize, Deserialize, Clone)]
@@ -73,21 +73,21 @@ pub struct PluginRequest {
     pub source_req: Option<PluginSourceRequest>,
     pub add_groups: Option<HashSet<Uuid>>,
     pub del_groups: Option<HashSet<Uuid>>,
-    pub mod_groups: Option<HashSet<Uuid>>
+    pub mod_groups: Option<HashSet<Uuid>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum PluginSort {
-    ByPluginId {
-        order: Order,
-        start: Option<Uuid>
-    }
+    ByPluginId { order: Order, start: Option<Uuid> },
 }
 
 impl UrlEncode for PluginSort {
     fn url_encode(&self, m: &mut HashMap<String, String>) {
         match *self {
-            PluginSort::ByPluginId{ ref order, ref start } => {
+            PluginSort::ByPluginId {
+                ref order,
+                ref start,
+            } => {
                 m.insert("sort".to_string(), format!("plugin_id:{}", order));
                 if let Some(v) = start {
                     m.insert("start".to_string(), v.to_string());
@@ -106,12 +106,12 @@ pub enum PluginSource {
         name: String,
         version: PluginVersion,
         language: Language,
-        code: String
+        code: String,
     },
     Inline {
         language: Language,
-        code: String
-    }
+        code: String,
+    },
 }
 
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
@@ -120,12 +120,12 @@ pub enum PluginSourceRequest {
     FromRepo {
         repo_url: String,
         plugin_name: String,
-        version: PluginVersion
+        version: PluginVersion,
     },
     Inline {
         language: Language,
-        code: String
-    }
+        code: String,
+    },
 }
 
 /// Type of a plugin.
@@ -134,7 +134,7 @@ pub enum PluginSourceRequest {
 pub enum PluginType {
     Standard,
     Impersonating,
-    CustomAlgorithm
+    CustomAlgorithm,
 }
 
 pub struct OperationCreatePlugin;
@@ -158,8 +158,10 @@ impl SdkmsClient {
         self.execute::<OperationCreatePlugin>(req, (), None)
     }
     pub fn request_approval_to_create_plugin(
-        &self, req: &PluginRequest,
-        description: Option<String>) -> Result<PendingApproval<OperationCreatePlugin>> {
+        &self,
+        req: &PluginRequest,
+        description: Option<String>,
+    ) -> Result<PendingApproval<OperationCreatePlugin>> {
         self.request_approval::<OperationCreatePlugin>(req, (), None, description)
     }
 }
@@ -178,7 +180,10 @@ impl Operation for OperationDeletePlugin {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/plugins/{id}", id = p.0)
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
+        None
+    }
+}
 
 impl SdkmsClient {
     pub fn delete_plugin(&self, id: &Uuid) -> Result<()> {
@@ -200,7 +205,10 @@ impl Operation for OperationGetPlugin {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/plugins/{id}", id = p.0)
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
+        None
+    }
+}
 
 impl SdkmsClient {
     pub fn get_plugin(&self, id: &Uuid) -> Result<Plugin> {
@@ -229,8 +237,11 @@ impl SdkmsClient {
         self.execute::<OperationInvokePlugin>(req, (id,), None)
     }
     pub fn request_approval_to_invoke_plugin(
-        &self, id: &Uuid, req: &serde_json::Value,
-        description: Option<String>) -> Result<PendingApproval<OperationInvokePlugin>> {
+        &self,
+        id: &Uuid,
+        req: &serde_json::Value,
+        description: Option<String>,
+    ) -> Result<PendingApproval<OperationInvokePlugin>> {
         self.request_approval::<OperationInvokePlugin>(req, (id,), None, description)
     }
 }
@@ -249,7 +260,10 @@ impl Operation for OperationListPlugins {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/plugins?{q}", q = q.encode())
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
+        None
+    }
+}
 
 impl SdkmsClient {
     pub fn list_plugins(&self, query_params: Option<&ListPluginsParams>) -> Result<Vec<Plugin>> {
@@ -278,9 +292,11 @@ impl SdkmsClient {
         self.execute::<OperationUpdatePlugin>(req, (id,), None)
     }
     pub fn request_approval_to_update_plugin(
-        &self, id: &Uuid, req: &PluginRequest,
-        description: Option<String>) -> Result<PendingApproval<OperationUpdatePlugin>> {
+        &self,
+        id: &Uuid,
+        req: &PluginRequest,
+        description: Option<String>,
+    ) -> Result<PendingApproval<OperationUpdatePlugin>> {
         self.request_approval::<OperationUpdatePlugin>(req, (id,), None, description)
     }
 }
-

--- a/src/generated/session_generated.rs
+++ b/src/generated/session_generated.rs
@@ -5,139 +5,192 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::*;
-use serde::{Deserialize, Serialize};
 
-/// A challenge used for multi-factor authentication.
-#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
-pub struct MfaChallengeResponse {
-    pub u2f_challenge: String,
-    pub u2f_keys: Vec<U2fRegisteredKey>,
+#[derive(Serialize, Deserialize, Clone, Default)]
+pub struct AuthDiscoverParams {
+    pub acct_id: Option<Uuid>
 }
 
-/// Description of a registered U2F device.
+impl UrlEncode for AuthDiscoverParams {
+    fn url_encode(&self, m: &mut HashMap<String, String>) {
+        if let Some(ref v) = self.acct_id {
+            m.insert("acct_id".to_string(), v.to_string());
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct AuthDiscoverRequest {
+    pub user_email: Option<String>
+}
+
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct U2fRegisteredKey {
-    pub key_handle: String,
-    pub version: String,
+#[serde(tag = "method", rename_all = "kebab-case")]
+pub enum AuthMethod {
+    Password,
+    SamlPost {
+        name: String,
+        icon_url: String,
+        id: String,
+        binding_url: String,
+        authn_request: String,
+        idp_id: Blob
+    },
+    OauthAuthCodeGrant {
+        name: String,
+        icon_url: String,
+        authorization_url: String,
+        client_id: String,
+        redirect_uri: String,
+        state: String,
+        idp_id: Blob
+    },
+    LdapPassword {
+        name: String,
+        icon_url: String,
+        idp_id: Blob
+    },
+    Vcd {
+        name: String,
+        authorization_url: String,
+        idp_id: Blob
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(tag = "method", rename_all = "kebab-case")]
+pub enum AuthRequest {
+    SamlResponse {
+        #[serde(default)]
+        id: Option<String>,
+        response: String
+    },
+    OauthAuthCode (
+        OauthCodeData
+    ),
+    LdapBasicAuth {
+        idp_id: Blob,
+        email: String,
+        password: String
+    },
+    AuthByAppName {
+        acct_id: Uuid,
+        name: String,
+        password: String
+    },
+    VcdAuthCode (
+        VcdCodeData
+    ),
+    AwsIam {
+        acct_id: Uuid,
+        region: String,
+        headers: HashMap<String,String>
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct AuthResponse {
+    pub token_type: String,
+    pub expires_in: u32,
+    pub access_token: String,
+    pub entity_id: Uuid,
+    #[serde(default)]
+    pub challenge: Option<MfaChallengeResponse>
+}
+
+#[derive(PartialEq, Eq, Hash, Debug, Serialize, Deserialize, Clone)]
+pub struct AwsTemporaryCredentials {
+    pub access_key: String,
+    pub secret_key: String,
+    pub session_token: String
+}
+
+/// Request to start configuring U2F.
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+pub struct Config2faAuthRequest {
+    pub password: String
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+pub struct Config2faAuthResponse {
+
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct OauthCodeData {
+    pub idp_id: Blob,
+    pub code: String,
+    pub email: String
+}
+
+/// Request to authenticate using U2F recovery code.
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
+pub struct RecoveryCodeAuthRequest {
+    pub recovery_code: String
 }
 
 /// Request to select an account.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct SelectAccountRequest {
-    pub acct_id: Uuid,
+    pub acct_id: Uuid
 }
 
 /// Response to select account request.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct SelectAccountResponse {
     #[serde(default)]
-    pub cookie: Option<String>,
+    pub cookie: Option<String>
 }
 
-/// Request to start configuring U2F.
-#[derive(Debug, Default, Serialize, Deserialize, Clone)]
-pub struct Config2faAuthRequest {
-    pub password: String,
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct VcdCodeData {
+    pub idp_id: Blob,
+    pub token: String,
+    pub email: String,
+    pub org: String
 }
 
-#[derive(Debug, Default, Serialize, Deserialize, Clone)]
-pub struct Config2faAuthResponse {}
-
-/// Request to authenticate using U2F recovery code.
-#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
-pub struct RecoveryCodeAuthRequest {
-    pub recovery_code: String,
-}
-
-pub struct OperationRefresh;
+pub struct OperationAuthDiscover;
 #[allow(unused)]
-impl Operation for OperationRefresh {
+impl Operation for OperationAuthDiscover {
     type PathParams = ();
-    type QueryParams = ();
-    type Body = ();
-    type Output = ();
+    type QueryParams = AuthDiscoverParams;
+    type Body = AuthDiscoverRequest;
+    type Output = Vec<AuthMethod>;
 
     fn method() -> Method {
         Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
-        format!("/sys/v1/session/refresh")
-    }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
-        None
+        format!("/sys/v1/session/auth/discover?{q}", q = q.encode())
     }
 }
 
 impl SdkmsClient {
-    pub fn refresh(&self) -> Result<()> {
-        self.execute::<OperationRefresh>(&(), (), None)
+    pub fn auth_discover(&self, query_params: Option<&AuthDiscoverParams>, req: &AuthDiscoverRequest) -> Result<Vec<AuthMethod>> {
+        self.execute::<OperationAuthDiscover>(req, (), query_params)
     }
 }
 
-pub struct OperationSelectAccount;
+pub struct OperationAuthenticate;
 #[allow(unused)]
-impl Operation for OperationSelectAccount {
+impl Operation for OperationAuthenticate {
     type PathParams = ();
     type QueryParams = ();
-    type Body = SelectAccountRequest;
-    type Output = SelectAccountResponse;
+    type Body = AuthRequest;
+    type Output = AuthResponse;
 
     fn method() -> Method {
         Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
-        format!("/sys/v1/session/select_account")
+        format!("/sys/v1/session/auth")
     }
 }
 
 impl SdkmsClient {
-    pub fn select_account(&self, req: &SelectAccountRequest) -> Result<SelectAccountResponse> {
-        self.execute::<OperationSelectAccount>(req, (), None)
-    }
-}
-
-pub struct OperationU2fAuth;
-#[allow(unused)]
-impl Operation for OperationU2fAuth {
-    type PathParams = ();
-    type QueryParams = ();
-    type Body = U2fAuthRequest;
-    type Output = ();
-
-    fn method() -> Method {
-        Method::POST
-    }
-    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
-        format!("/sys/v1/session/auth/2fa/u2f")
-    }
-}
-
-impl SdkmsClient {
-    pub fn u2f_auth(&self, req: &U2fAuthRequest) -> Result<()> {
-        self.execute::<OperationU2fAuth>(req, (), None)
-    }
-}
-
-pub struct OperationRecoveryCodeAuth;
-#[allow(unused)]
-impl Operation for OperationRecoveryCodeAuth {
-    type PathParams = ();
-    type QueryParams = ();
-    type Body = RecoveryCodeAuthRequest;
-    type Output = ();
-
-    fn method() -> Method {
-        Method::POST
-    }
-    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
-        format!("/sys/v1/session/auth/2fa/recovery_code")
-    }
-}
-
-impl SdkmsClient {
-    pub fn recovery_code_auth(&self, req: &RecoveryCodeAuthRequest) -> Result<()> {
-        self.execute::<OperationRecoveryCodeAuth>(req, (), None)
+    pub fn authenticate(&self, req: &AuthRequest) -> Result<AuthResponse> {
+        self.execute::<OperationAuthenticate>(req, (), None)
     }
 }
 
@@ -177,14 +230,165 @@ impl Operation for OperationConfig2faTerminate {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/session/config_2fa/terminate")
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
-        None
-    }
-}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
 
 impl SdkmsClient {
     pub fn config_2fa_terminate(&self) -> Result<()> {
         self.execute::<OperationConfig2faTerminate>(&(), (), None)
+    }
+}
+
+pub struct OperationReauthenticate;
+#[allow(unused)]
+impl Operation for OperationReauthenticate {
+    type PathParams = ();
+    type QueryParams = ();
+    type Body = ();
+    type Output = AuthResponse;
+
+    fn method() -> Method {
+        Method::POST
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/sys/v1/session/reauth")
+    }
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+
+impl SdkmsClient {
+    pub fn reauthenticate(&self) -> Result<AuthResponse> {
+        self.execute::<OperationReauthenticate>(&(), (), None)
+    }
+}
+
+pub struct OperationRecoveryCodeAuth;
+#[allow(unused)]
+impl Operation for OperationRecoveryCodeAuth {
+    type PathParams = ();
+    type QueryParams = ();
+    type Body = RecoveryCodeAuthRequest;
+    type Output = ();
+
+    fn method() -> Method {
+        Method::POST
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/sys/v1/session/auth/2fa/recovery_code")
+    }
+}
+
+impl SdkmsClient {
+    pub fn recovery_code_auth(&self, req: &RecoveryCodeAuthRequest) -> Result<()> {
+        self.execute::<OperationRecoveryCodeAuth>(req, (), None)
+    }
+}
+
+pub struct OperationRefresh;
+#[allow(unused)]
+impl Operation for OperationRefresh {
+    type PathParams = ();
+    type QueryParams = ();
+    type Body = ();
+    type Output = ();
+
+    fn method() -> Method {
+        Method::POST
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/sys/v1/session/refresh")
+    }
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+
+impl SdkmsClient {
+    pub fn refresh(&self) -> Result<()> {
+        self.execute::<OperationRefresh>(&(), (), None)
+    }
+}
+
+pub struct OperationSelectAccount;
+#[allow(unused)]
+impl Operation for OperationSelectAccount {
+    type PathParams = ();
+    type QueryParams = ();
+    type Body = SelectAccountRequest;
+    type Output = SelectAccountResponse;
+
+    fn method() -> Method {
+        Method::POST
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/sys/v1/session/select_account")
+    }
+}
+
+impl SdkmsClient {
+    pub fn select_account(&self, req: &SelectAccountRequest) -> Result<SelectAccountResponse> {
+        self.execute::<OperationSelectAccount>(req, (), None)
+    }
+}
+
+pub struct OperationSetAwsTemporaryCredentials;
+#[allow(unused)]
+impl Operation for OperationSetAwsTemporaryCredentials {
+    type PathParams = ();
+    type QueryParams = ();
+    type Body = AwsTemporaryCredentials;
+    type Output = ();
+
+    fn method() -> Method {
+        Method::POST
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/sys/v1/session/aws_temporary_credentials")
+    }
+}
+
+impl SdkmsClient {
+    pub fn set_aws_temporary_credentials(&self, req: &AwsTemporaryCredentials) -> Result<()> {
+        self.execute::<OperationSetAwsTemporaryCredentials>(req, (), None)
+    }
+}
+
+pub struct OperationTerminate;
+#[allow(unused)]
+impl Operation for OperationTerminate {
+    type PathParams = ();
+    type QueryParams = ();
+    type Body = ();
+    type Output = ();
+
+    fn method() -> Method {
+        Method::POST
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/sys/v1/session/terminate")
+    }
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+
+impl SdkmsClient {
+    pub fn terminate(&self) -> Result<()> {
+        self.execute::<OperationTerminate>(&(), (), None)
+    }
+}
+
+pub struct OperationU2fAuth;
+#[allow(unused)]
+impl Operation for OperationU2fAuth {
+    type PathParams = ();
+    type QueryParams = ();
+    type Body = U2fAuthRequest;
+    type Output = ();
+
+    fn method() -> Method {
+        Method::POST
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/sys/v1/session/auth/2fa/u2f")
+    }
+}
+
+impl SdkmsClient {
+    pub fn u2f_auth(&self, req: &U2fAuthRequest) -> Result<()> {
+        self.execute::<OperationU2fAuth>(req, (), None)
     }
 }
 
@@ -202,13 +406,11 @@ impl Operation for OperationU2fNewChallenge {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/session/config_2fa/new_challenge")
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
-        None
-    }
-}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
 
 impl SdkmsClient {
     pub fn u2f_new_challenge(&self) -> Result<MfaChallengeResponse> {
         self.execute::<OperationU2fNewChallenge>(&(), (), None)
     }
 }
+

--- a/src/generated/session_generated.rs
+++ b/src/generated/session_generated.rs
@@ -8,7 +8,7 @@ use super::*;
 
 #[derive(Serialize, Deserialize, Clone, Default)]
 pub struct AuthDiscoverParams {
-    pub acct_id: Option<Uuid>
+    pub acct_id: Option<Uuid>,
 }
 
 impl UrlEncode for AuthDiscoverParams {
@@ -21,7 +21,7 @@ impl UrlEncode for AuthDiscoverParams {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct AuthDiscoverRequest {
-    pub user_email: Option<String>
+    pub user_email: Option<String>,
 }
 
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
@@ -34,7 +34,7 @@ pub enum AuthMethod {
         id: String,
         binding_url: String,
         authn_request: String,
-        idp_id: Blob
+        idp_id: Blob,
     },
     OauthAuthCodeGrant {
         name: String,
@@ -43,18 +43,18 @@ pub enum AuthMethod {
         client_id: String,
         redirect_uri: String,
         state: String,
-        idp_id: Blob
+        idp_id: Blob,
     },
     LdapPassword {
         name: String,
         icon_url: String,
-        idp_id: Blob
+        idp_id: Blob,
     },
     Vcd {
         name: String,
         authorization_url: String,
-        idp_id: Blob
-    }
+        idp_id: Blob,
+    },
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -63,29 +63,25 @@ pub enum AuthRequest {
     SamlResponse {
         #[serde(default)]
         id: Option<String>,
-        response: String
+        response: String,
     },
-    OauthAuthCode (
-        OauthCodeData
-    ),
+    OauthAuthCode(OauthCodeData),
     LdapBasicAuth {
         idp_id: Blob,
         email: String,
-        password: String
+        password: String,
     },
     AuthByAppName {
         acct_id: Uuid,
         name: String,
-        password: String
+        password: String,
     },
-    VcdAuthCode (
-        VcdCodeData
-    ),
+    VcdAuthCode(VcdCodeData),
     AwsIam {
         acct_id: Uuid,
         region: String,
-        headers: HashMap<String,String>
-    }
+        headers: HashMap<String, String>,
+    },
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -95,51 +91,49 @@ pub struct AuthResponse {
     pub access_token: String,
     pub entity_id: Uuid,
     #[serde(default)]
-    pub challenge: Option<MfaChallengeResponse>
+    pub challenge: Option<MfaChallengeResponse>,
 }
 
 #[derive(PartialEq, Eq, Hash, Debug, Serialize, Deserialize, Clone)]
 pub struct AwsTemporaryCredentials {
     pub access_key: String,
     pub secret_key: String,
-    pub session_token: String
+    pub session_token: String,
 }
 
 /// Request to start configuring U2F.
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
 pub struct Config2faAuthRequest {
-    pub password: String
+    pub password: String,
 }
 
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
-pub struct Config2faAuthResponse {
-
-}
+pub struct Config2faAuthResponse {}
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct OauthCodeData {
     pub idp_id: Blob,
     pub code: String,
-    pub email: String
+    pub email: String,
 }
 
 /// Request to authenticate using U2F recovery code.
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
 pub struct RecoveryCodeAuthRequest {
-    pub recovery_code: String
+    pub recovery_code: String,
 }
 
 /// Request to select an account.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct SelectAccountRequest {
-    pub acct_id: Uuid
+    pub acct_id: Uuid,
 }
 
 /// Response to select account request.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct SelectAccountResponse {
     #[serde(default)]
-    pub cookie: Option<String>
+    pub cookie: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -147,7 +141,7 @@ pub struct VcdCodeData {
     pub idp_id: Blob,
     pub token: String,
     pub email: String,
-    pub org: String
+    pub org: String,
 }
 
 pub struct OperationAuthDiscover;
@@ -167,7 +161,11 @@ impl Operation for OperationAuthDiscover {
 }
 
 impl SdkmsClient {
-    pub fn auth_discover(&self, query_params: Option<&AuthDiscoverParams>, req: &AuthDiscoverRequest) -> Result<Vec<AuthMethod>> {
+    pub fn auth_discover(
+        &self,
+        query_params: Option<&AuthDiscoverParams>,
+        req: &AuthDiscoverRequest,
+    ) -> Result<Vec<AuthMethod>> {
         self.execute::<OperationAuthDiscover>(req, (), query_params)
     }
 }
@@ -230,7 +228,10 @@ impl Operation for OperationConfig2faTerminate {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/session/config_2fa/terminate")
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
+        None
+    }
+}
 
 impl SdkmsClient {
     pub fn config_2fa_terminate(&self) -> Result<()> {
@@ -252,7 +253,10 @@ impl Operation for OperationReauthenticate {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/session/reauth")
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
+        None
+    }
+}
 
 impl SdkmsClient {
     pub fn reauthenticate(&self) -> Result<AuthResponse> {
@@ -296,7 +300,10 @@ impl Operation for OperationRefresh {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/session/refresh")
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
+        None
+    }
+}
 
 impl SdkmsClient {
     pub fn refresh(&self) -> Result<()> {
@@ -362,7 +369,10 @@ impl Operation for OperationTerminate {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/session/terminate")
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
+        None
+    }
+}
 
 impl SdkmsClient {
     pub fn terminate(&self) -> Result<()> {
@@ -406,11 +416,13 @@ impl Operation for OperationU2fNewChallenge {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/session/config_2fa/new_challenge")
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
+        None
+    }
+}
 
 impl SdkmsClient {
     pub fn u2f_new_challenge(&self) -> Result<MfaChallengeResponse> {
         self.execute::<OperationU2fNewChallenge>(&(), (), None)
     }
 }
-

--- a/src/generated/stats_generated.rs
+++ b/src/generated/stats_generated.rs
@@ -1,0 +1,183 @@
+/* Copyright (c) Fortanix, Inc.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use super::*;
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct EsCountStatsLog {
+    pub buckets: Vec<OuterEsBucket>
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct EsStatsCountQueryResponse {
+    pub time: EsCountStatsLog
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct EsTotalTxn {
+    pub buckets: Vec<InnerEsBucket>
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct InnerEsBucket {
+    pub doc_count: u64,
+    pub key: Uuid,
+    #[serde(default)]
+    pub unique_operations_count: Option<UniqueOperationsCount>,
+    #[serde(default)]
+    pub unique_active_sobj_count: Option<UniqueOperationsCount>,
+    #[serde(default)]
+    pub unique_active_app_count: Option<UniqueOperationsCount>
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct OuterEsBucket {
+    pub doc_count: u64,
+    pub key: u64,
+    pub key_as_string: String,
+    pub total_txn: EsTotalTxn
+}
+
+#[derive(Serialize, Deserialize, Clone, Default)]
+pub struct StatsParams {
+    pub num_points: Option<u64>,
+    pub top_count: Option<u32>,
+    pub range_from: Option<u64>,
+    pub range_to: Option<u64>
+}
+
+impl UrlEncode for StatsParams {
+    fn url_encode(&self, m: &mut HashMap<String, String>) {
+        if let Some(ref v) = self.num_points {
+            m.insert("num_points".to_string(), v.to_string());
+        }
+        if let Some(ref v) = self.top_count {
+            m.insert("top_count".to_string(), v.to_string());
+        }
+        if let Some(ref v) = self.range_from {
+            m.insert("range_from".to_string(), v.to_string());
+        }
+        if let Some(ref v) = self.range_to {
+            m.insert("range_to".to_string(), v.to_string());
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct UniqueOperationsCount {
+    pub value: u64
+}
+
+pub struct OperationGetAppAggregate;
+#[allow(unused)]
+impl Operation for OperationGetAppAggregate {
+    type PathParams = ();
+    type QueryParams = StatsParams;
+    type Body = ();
+    type Output = EsStatsCountQueryResponse;
+
+    fn method() -> Method {
+        Method::GET
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/sys/v1/stats/apps?{q}", q = q.encode())
+    }
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+
+impl SdkmsClient {
+    pub fn get_app_aggregate(&self, query_params: Option<&StatsParams>) -> Result<EsStatsCountQueryResponse> {
+        self.execute::<OperationGetAppAggregate>(&(), (), query_params)
+    }
+}
+
+pub struct OperationGetAppStats;
+#[allow(unused)]
+impl Operation for OperationGetAppStats {
+    type PathParams = (Uuid,);
+    type QueryParams = StatsParams;
+    type Body = ();
+    type Output = EsStatsCountQueryResponse;
+
+    fn method() -> Method {
+        Method::GET
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/sys/v1/stats/{id}/app?{q}", id = p.0, q = q.encode())
+    }
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+
+impl SdkmsClient {
+    pub fn get_app_stats(&self, id: &Uuid, query_params: Option<&StatsParams>) -> Result<EsStatsCountQueryResponse> {
+        self.execute::<OperationGetAppStats>(&(), (id,), query_params)
+    }
+}
+
+pub struct OperationGetGroupAggregate;
+#[allow(unused)]
+impl Operation for OperationGetGroupAggregate {
+    type PathParams = ();
+    type QueryParams = StatsParams;
+    type Body = ();
+    type Output = EsStatsCountQueryResponse;
+
+    fn method() -> Method {
+        Method::GET
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/sys/v1/stats/groups?{q}", q = q.encode())
+    }
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+
+impl SdkmsClient {
+    pub fn get_group_aggregate(&self, query_params: Option<&StatsParams>) -> Result<EsStatsCountQueryResponse> {
+        self.execute::<OperationGetGroupAggregate>(&(), (), query_params)
+    }
+}
+
+pub struct OperationGetGroupStats;
+#[allow(unused)]
+impl Operation for OperationGetGroupStats {
+    type PathParams = (Uuid,);
+    type QueryParams = StatsParams;
+    type Body = ();
+    type Output = EsStatsCountQueryResponse;
+
+    fn method() -> Method {
+        Method::GET
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/sys/v1/stats/{id}/group?{q}", id = p.0, q = q.encode())
+    }
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+
+impl SdkmsClient {
+    pub fn get_group_stats(&self, id: &Uuid, query_params: Option<&StatsParams>) -> Result<EsStatsCountQueryResponse> {
+        self.execute::<OperationGetGroupStats>(&(), (id,), query_params)
+    }
+}
+
+pub struct OperationGetSobjectStats;
+#[allow(unused)]
+impl Operation for OperationGetSobjectStats {
+    type PathParams = (Uuid,);
+    type QueryParams = StatsParams;
+    type Body = ();
+    type Output = EsStatsCountQueryResponse;
+
+    fn method() -> Method {
+        Method::GET
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/sys/v1/stats/{id}/key?{q}", id = p.0, q = q.encode())
+    }
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+
+impl SdkmsClient {
+    pub fn get_sobject_stats(&self, id: &Uuid, query_params: Option<&StatsParams>) -> Result<EsStatsCountQueryResponse> {
+        self.execute::<OperationGetSobjectStats>(&(), (id,), query_params)
+    }
+}
+

--- a/src/generated/users_generated.rs
+++ b/src/generated/users_generated.rs
@@ -5,26 +5,122 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::*;
-use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
+pub struct ConfirmEmailRequest {
+    pub confirm_token: String
+}
+
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
+pub struct ConfirmEmailResponse {
+    pub user_email: String
+}
+
+/// Initiate password reset sequence.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ForgotPasswordRequest {
+    pub user_email: String
+}
+
+#[derive(Serialize, Deserialize, Clone, Default)]
+pub struct ListUsersParams {
+    pub group_id: Option<Uuid>,
+    pub acct_id: Option<Uuid>,
+    pub limit: Option<usize>,
+    pub offset: Option<usize>,
+    #[serde(flatten)]
+    pub sort: UserSort
+}
+
+impl UrlEncode for ListUsersParams {
+    fn url_encode(&self, m: &mut HashMap<String, String>) {
+        if let Some(ref v) = self.group_id {
+            m.insert("group_id".to_string(), v.to_string());
+        }
+        if let Some(ref v) = self.acct_id {
+            m.insert("acct_id".to_string(), v.to_string());
+        }
+        if let Some(ref v) = self.limit {
+            m.insert("limit".to_string(), v.to_string());
+        }
+        if let Some(ref v) = self.offset {
+            m.insert("offset".to_string(), v.to_string());
+        }
+        self.sort.url_encode(m);
+    }
+}
+
+/// Request to change user's password.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct PasswordChangeRequest {
+    pub current_password: String,
+    pub new_password: String
+}
+
+/// Request to perform a password reset.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct PasswordResetRequest {
+    pub reset_token: String,
+    pub new_password: String
+}
+
+/// Accept/reject invitations to join account.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ProcessInviteRequest {
+    /// Optional list of account IDs to accept.
+    #[serde(default)]
+    pub accepts: Option<HashSet<Uuid>>,
+    /// Optional list of account IDs to reject.
+    #[serde(default)]
+    pub rejects: Option<HashSet<Uuid>>
+}
 
 /// U2F recovery codes.
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
 pub struct RecoveryCodes {
-    pub recovery_codes: Vec<String>,
+    pub recovery_codes: Vec<String>
 }
 
-/// User's role and state in an account.
-pub use self::user_flags::UserAccountFlags;
-pub mod user_flags {
-    bitflags_set! {
-        pub struct UserAccountFlags: u64 {
-            const ACCOUNTADMINISTRATOR = 0x0000000000000001;
-            const ACCOUNTMEMBER = 0x0000000000000002;
-            const ACCOUNTAUDITOR = 0x0000000000000004;
-            const STATEENABLED = 0x0000000000000008;
-            const PENDINGINVITE = 0x0000000000000010;
-        }
-    }
+/// Request to signup a new user.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SignupRequest {
+    pub user_email: String,
+    pub user_password: String,
+    #[serde(default)]
+    pub recaptcha_response: Option<String>,
+    #[serde(default)]
+    pub first_name: Option<String>,
+    #[serde(default)]
+    pub last_name: Option<String>
+}
+
+/// Description of a U2F device to add for two factor authentication.
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct U2fAddDeviceRequest {
+    pub name: String,
+    pub registration_data: Blob,
+    pub client_data: Blob,
+    pub version: String
+}
+
+/// Request to delete a U2F device.
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
+pub struct U2fDelDeviceRequest {
+    pub name: String
+}
+
+/// A U2f device that may be used for second factor authentication.
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
+pub struct U2fDevice {
+    pub name: String
+}
+
+/// Request to rename a U2F device.
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
+pub struct U2fRenameDeviceRequest {
+    pub old_name: String,
+    pub new_name: String
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
@@ -38,7 +134,9 @@ pub struct User {
     pub email_verified: Option<bool>,
     #[serde(default)]
     pub first_name: Option<String>,
-    pub groups: HashMap<Uuid, UserGroupRole>,
+    pub groups: HashMap<Uuid,UserGroupRole>,
+    #[serde(default)]
+    pub has_account: Option<bool>,
     #[serde(default)]
     pub has_password: Option<bool>,
     #[serde(default)]
@@ -50,7 +148,21 @@ pub struct User {
     pub u2f_devices: Vec<U2fDevice>,
     #[serde(default)]
     pub user_email: Option<String>,
-    pub user_id: Uuid,
+    pub user_id: Uuid
+}
+
+/// User's role and state in an account.
+pub use self::user_flags::UserAccountFlags;
+pub mod user_flags {
+    bitflags_set!{
+        pub struct UserAccountFlags: u64 {
+            const ACCOUNTADMINISTRATOR = 0x0000000000000001;
+            const ACCOUNTMEMBER = 0x0000000000000002;
+            const ACCOUNTAUDITOR = 0x0000000000000004;
+            const STATEENABLED = 0x0000000000000008;
+            const PENDINGINVITE = 0x0000000000000010;
+        }
+    }
 }
 
 #[derive(Default, Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
@@ -58,11 +170,11 @@ pub struct UserRequest {
     #[serde(default)]
     pub account_role: Option<UserAccountFlags>,
     #[serde(default)]
-    pub add_groups: Option<HashMap<Uuid, UserGroupRole>>,
+    pub add_groups: Option<HashMap<Uuid,UserGroupRole>>,
     #[serde(default)]
     pub add_u2f_devices: Option<Vec<U2fAddDeviceRequest>>,
     #[serde(default)]
-    pub del_groups: Option<HashMap<Uuid, UserGroupRole>>,
+    pub del_groups: Option<HashMap<Uuid,UserGroupRole>>,
     #[serde(default)]
     pub del_u2f_devices: Option<Vec<U2fDelDeviceRequest>>,
     #[serde(default)]
@@ -74,250 +186,153 @@ pub struct UserRequest {
     #[serde(default)]
     pub last_name: Option<String>,
     #[serde(default)]
-    pub mod_groups: Option<HashMap<Uuid, UserGroupRole>>,
+    pub mod_groups: Option<HashMap<Uuid,UserGroupRole>>,
     #[serde(default)]
     pub rename_u2f_devices: Option<Vec<U2fRenameDeviceRequest>>,
     #[serde(default)]
     pub user_email: Option<String>,
     #[serde(default)]
-    pub user_password: Option<String>,
-}
-
-/// Description of a U2F device to add for two factor authentication.
-#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct U2fAddDeviceRequest {
-    pub name: String,
-    pub registration_data: Blob,
-    pub client_data: Blob,
-    pub version: String,
-}
-
-/// Request to rename a U2F device.
-#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
-pub struct U2fRenameDeviceRequest {
-    pub old_name: String,
-    pub new_name: String,
-}
-
-/// Request to delete a U2F device.
-#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
-pub struct U2fDelDeviceRequest {
-    pub name: String,
-}
-
-/// A U2f device that may be used for second factor authentication.
-#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
-pub struct U2fDevice {
-    pub name: String,
-}
-
-/// Request to change user's password.
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct PasswordChangeRequest {
-    pub current_password: String,
-    pub new_password: String,
-}
-
-/// Accept/reject invitations to join account.
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct ProcessInviteRequest {
-    /// Optional list of account IDs to accept.
-    #[serde(default)]
-    pub accepts: Option<HashSet<Uuid>>,
-    /// Optional list of account IDs to reject.
-    #[serde(default)]
-    pub rejects: Option<HashSet<Uuid>>,
-}
-
-/// Initiate password reset sequence.
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct ForgotPasswordRequest {
-    pub user_email: String,
-}
-
-/// Request to perform a password reset.
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct PasswordResetRequest {
-    pub reset_token: String,
-    pub new_password: String,
-}
-
-/// Request to signup a new user.
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct SignupRequest {
-    pub user_email: String,
-    pub user_password: String,
-    #[serde(default)]
-    pub recaptcha_response: Option<String>,
-    #[serde(default)]
-    pub first_name: Option<String>,
-    #[serde(default)]
-    pub last_name: Option<String>,
-}
-
-#[derive(Serialize, Deserialize, Clone, Default)]
-pub struct ListUsersParams {
-    pub group_id: Option<Uuid>,
-    pub acct_id: Option<Uuid>,
-    pub limit: Option<usize>,
-    pub offset: Option<usize>,
-    #[serde(flatten)]
-    pub sort: UserSort,
-}
-
-impl UrlEncode for ListUsersParams {
-    fn url_encode(&self, m: &mut HashMap<&'static str, String>) {
-        if let Some(ref v) = self.group_id {
-            m.insert("group_id", v.to_string());
-        }
-        if let Some(ref v) = self.acct_id {
-            m.insert("acct_id", v.to_string());
-        }
-        if let Some(ref v) = self.limit {
-            m.insert("limit", v.to_string());
-        }
-        if let Some(ref v) = self.offset {
-            m.insert("offset", v.to_string());
-        }
-        self.sort.url_encode(m);
-    }
+    pub user_password: Option<String>
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum UserSort {
-    ByUserId { order: Order, start: Option<Uuid> },
+    ByUserId {
+        order: Order,
+        start: Option<Uuid>
+    }
 }
 
 impl UrlEncode for UserSort {
-    fn url_encode(&self, m: &mut HashMap<&'static str, String>) {
+    fn url_encode(&self, m: &mut HashMap<String, String>) {
         match *self {
-            UserSort::ByUserId {
-                ref order,
-                ref start,
-            } => {
-                m.insert("sort", format!("user_id:{}", order));
+            UserSort::ByUserId{ ref order, ref start } => {
+                m.insert("sort".to_string(), format!("user_id:{}", order));
                 if let Some(v) = start {
-                    m.insert("start", v.to_string());
+                    m.insert("start".to_string(), v.to_string());
                 }
             }
         }
     }
 }
 
-pub struct OperationSignupUser;
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ValidateTokenRequest {
+    pub reset_token: String
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ValidateTokenResponse {
+    pub user_email: String
+}
+
+pub struct OperationChangePassword;
 #[allow(unused)]
-impl Operation for OperationSignupUser {
+impl Operation for OperationChangePassword {
     type PathParams = ();
     type QueryParams = ();
-    type Body = SignupRequest;
-    type Output = User;
-
-    fn method() -> Method {
-        Method::POST
-    }
-    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
-        format!("/sys/v1/users")
-    }
-}
-
-impl SdkmsClient {
-    pub fn signup_user(&self, req: &SignupRequest) -> Result<User> {
-        self.execute::<OperationSignupUser>(req, (), None)
-    }
-}
-
-pub struct OperationListUsers;
-#[allow(unused)]
-impl Operation for OperationListUsers {
-    type PathParams = ();
-    type QueryParams = ListUsersParams;
-    type Body = ();
-    type Output = Vec<User>;
-
-    fn method() -> Method {
-        Method::GET
-    }
-    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
-        format!("/sys/v1/users?{q}", q = q.encode())
-    }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
-        None
-    }
-}
-
-impl SdkmsClient {
-    pub fn list_users(&self, query_params: Option<&ListUsersParams>) -> Result<Vec<User>> {
-        self.execute::<OperationListUsers>(&(), (), query_params)
-    }
-}
-
-pub struct OperationGetUser;
-#[allow(unused)]
-impl Operation for OperationGetUser {
-    type PathParams = (Uuid,);
-    type QueryParams = ();
-    type Body = ();
-    type Output = User;
-
-    fn method() -> Method {
-        Method::GET
-    }
-    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
-        format!("/sys/v1/users/{id}", id = p.0)
-    }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
-        None
-    }
-}
-
-impl SdkmsClient {
-    pub fn get_user(&self, id: &Uuid) -> Result<User> {
-        self.execute::<OperationGetUser>(&(), (id,), None)
-    }
-}
-
-pub struct OperationUpdateUser;
-#[allow(unused)]
-impl Operation for OperationUpdateUser {
-    type PathParams = (Uuid,);
-    type QueryParams = ();
-    type Body = UserRequest;
-    type Output = User;
-
-    fn method() -> Method {
-        Method::PATCH
-    }
-    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
-        format!("/sys/v1/users/{id}", id = p.0)
-    }
-}
-
-impl SdkmsClient {
-    pub fn update_user(&self, id: &Uuid, req: &UserRequest) -> Result<User> {
-        self.execute::<OperationUpdateUser>(req, (id,), None)
-    }
-}
-
-pub struct OperationResetPassword;
-#[allow(unused)]
-impl Operation for OperationResetPassword {
-    type PathParams = (Uuid,);
-    type QueryParams = ();
-    type Body = PasswordResetRequest;
+    type Body = PasswordChangeRequest;
     type Output = ();
 
     fn method() -> Method {
         Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
-        format!("/sys/v1/users/{id}/reset_password", id = p.0)
+        format!("/sys/v1/users/change_password")
     }
 }
 
 impl SdkmsClient {
-    pub fn reset_password(&self, id: &Uuid, req: &PasswordResetRequest) -> Result<()> {
-        self.execute::<OperationResetPassword>(req, (id,), None)
+    pub fn change_password(&self, req: &PasswordChangeRequest) -> Result<()> {
+        self.execute::<OperationChangePassword>(req, (), None)
+    }
+}
+
+pub struct OperationConfirmEmail;
+#[allow(unused)]
+impl Operation for OperationConfirmEmail {
+    type PathParams = (Uuid,);
+    type QueryParams = ();
+    type Body = ConfirmEmailRequest;
+    type Output = ConfirmEmailResponse;
+
+    fn method() -> Method {
+        Method::POST
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/sys/v1/users/{id}/confirm_email", id = p.0)
+    }
+}
+
+impl SdkmsClient {
+    pub fn confirm_email(&self, id: &Uuid, req: &ConfirmEmailRequest) -> Result<ConfirmEmailResponse> {
+        self.execute::<OperationConfirmEmail>(req, (id,), None)
+    }
+}
+
+pub struct OperationDeleteStale;
+#[allow(unused)]
+impl Operation for OperationDeleteStale {
+    type PathParams = (Uuid,);
+    type QueryParams = ();
+    type Body = ();
+    type Output = ();
+
+    fn method() -> Method {
+        Method::DELETE
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/sys/v1/users/{id}", id = p.0)
+    }
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+
+impl SdkmsClient {
+    pub fn delete_stale(&self, id: &Uuid) -> Result<()> {
+        self.execute::<OperationDeleteStale>(&(), (id,), None)
+    }
+}
+
+pub struct OperationDeleteUser;
+#[allow(unused)]
+impl Operation for OperationDeleteUser {
+    type PathParams = ();
+    type QueryParams = ();
+    type Body = ();
+    type Output = ();
+
+    fn method() -> Method {
+        Method::DELETE
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/sys/v1/users")
+    }
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+
+impl SdkmsClient {
+    pub fn delete_user(&self) -> Result<()> {
+        self.execute::<OperationDeleteUser>(&(), (), None)
+    }
+}
+
+pub struct OperationDeleteUserAccount;
+#[allow(unused)]
+impl Operation for OperationDeleteUserAccount {
+    type PathParams = (Uuid,);
+    type QueryParams = ();
+    type Body = ();
+    type Output = ();
+
+    fn method() -> Method {
+        Method::DELETE
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/sys/v1/users/{id}/accounts", id = p.0)
+    }
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+
+impl SdkmsClient {
+    pub fn delete_user_account(&self, id: &Uuid) -> Result<()> {
+        self.execute::<OperationDeleteUserAccount>(&(), (id,), None)
     }
 }
 
@@ -343,6 +358,72 @@ impl SdkmsClient {
     }
 }
 
+pub struct OperationGenerateRecoveryCodes;
+#[allow(unused)]
+impl Operation for OperationGenerateRecoveryCodes {
+    type PathParams = ();
+    type QueryParams = ();
+    type Body = ();
+    type Output = RecoveryCodes;
+
+    fn method() -> Method {
+        Method::POST
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/sys/v1/users/generate_recovery_codes")
+    }
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+
+impl SdkmsClient {
+    pub fn generate_recovery_codes(&self) -> Result<RecoveryCodes> {
+        self.execute::<OperationGenerateRecoveryCodes>(&(), (), None)
+    }
+}
+
+pub struct OperationGetUser;
+#[allow(unused)]
+impl Operation for OperationGetUser {
+    type PathParams = (Uuid,);
+    type QueryParams = ();
+    type Body = ();
+    type Output = User;
+
+    fn method() -> Method {
+        Method::GET
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/sys/v1/users/{id}", id = p.0)
+    }
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+
+impl SdkmsClient {
+    pub fn get_user(&self, id: &Uuid) -> Result<User> {
+        self.execute::<OperationGetUser>(&(), (id,), None)
+    }
+}
+
+pub struct OperationGetUserAccounts;
+#[allow(unused)]
+impl Operation for OperationGetUserAccounts {
+    type PathParams = ();
+    type QueryParams = ();
+    type Body = ();
+    type Output = HashMap<Uuid,UserAccountFlags>;
+
+    fn method() -> Method {
+        Method::GET
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/sys/v1/users/accounts")
+    }
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+
+impl SdkmsClient {
+    pub fn get_user_accounts(&self) -> Result<HashMap<Uuid,UserAccountFlags>> {
+        self.execute::<OperationGetUserAccounts>(&(), (), None)
+    }
+}
+
 pub struct OperationInviteUser;
 #[allow(unused)]
 impl Operation for OperationInviteUser {
@@ -362,6 +443,28 @@ impl Operation for OperationInviteUser {
 impl SdkmsClient {
     pub fn invite_user(&self, req: &UserRequest) -> Result<User> {
         self.execute::<OperationInviteUser>(req, (), None)
+    }
+}
+
+pub struct OperationListUsers;
+#[allow(unused)]
+impl Operation for OperationListUsers {
+    type PathParams = ();
+    type QueryParams = ListUsersParams;
+    type Body = ();
+    type Output = Vec<User>;
+
+    fn method() -> Method {
+        Method::GET
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/sys/v1/users?{q}", q = q.encode())
+    }
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+
+impl SdkmsClient {
+    pub fn list_users(&self, query_params: Option<&ListUsersParams>) -> Result<Vec<User>> {
+        self.execute::<OperationListUsers>(&(), (), query_params)
     }
 }
 
@@ -387,6 +490,28 @@ impl SdkmsClient {
     }
 }
 
+pub struct OperationResendConfirmEmail;
+#[allow(unused)]
+impl Operation for OperationResendConfirmEmail {
+    type PathParams = ();
+    type QueryParams = ();
+    type Body = ();
+    type Output = ();
+
+    fn method() -> Method {
+        Method::POST
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/sys/v1/users/resend_confirm_email")
+    }
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+
+impl SdkmsClient {
+    pub fn resend_confirm_email(&self) -> Result<()> {
+        self.execute::<OperationResendConfirmEmail>(&(), (), None)
+    }
+}
+
 pub struct OperationResendInvite;
 #[allow(unused)]
 impl Operation for OperationResendInvite {
@@ -401,10 +526,7 @@ impl Operation for OperationResendInvite {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/users/{id}/resend_invite", id = p.0)
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
-        None
-    }
-}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
 
 impl SdkmsClient {
     pub fn resend_invite(&self, id: &Uuid) -> Result<()> {
@@ -412,124 +534,91 @@ impl SdkmsClient {
     }
 }
 
-pub struct OperationDeleteUser;
+pub struct OperationResetPassword;
 #[allow(unused)]
-impl Operation for OperationDeleteUser {
-    type PathParams = ();
+impl Operation for OperationResetPassword {
+    type PathParams = (Uuid,);
     type QueryParams = ();
-    type Body = ();
+    type Body = PasswordResetRequest;
     type Output = ();
 
     fn method() -> Method {
-        Method::DELETE
+        Method::POST
+    }
+    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
+        format!("/sys/v1/users/{id}/reset_password", id = p.0)
+    }
+}
+
+impl SdkmsClient {
+    pub fn reset_password(&self, id: &Uuid, req: &PasswordResetRequest) -> Result<()> {
+        self.execute::<OperationResetPassword>(req, (id,), None)
+    }
+}
+
+pub struct OperationSignupUser;
+#[allow(unused)]
+impl Operation for OperationSignupUser {
+    type PathParams = ();
+    type QueryParams = ();
+    type Body = SignupRequest;
+    type Output = User;
+
+    fn method() -> Method {
+        Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/users")
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
-        None
-    }
 }
 
 impl SdkmsClient {
-    pub fn delete_user(&self) -> Result<()> {
-        self.execute::<OperationDeleteUser>(&(), (), None)
+    pub fn signup_user(&self, req: &SignupRequest) -> Result<User> {
+        self.execute::<OperationSignupUser>(req, (), None)
     }
 }
 
-pub struct OperationChangePassword;
+pub struct OperationUpdateUser;
 #[allow(unused)]
-impl Operation for OperationChangePassword {
-    type PathParams = ();
-    type QueryParams = ();
-    type Body = PasswordChangeRequest;
-    type Output = ();
-
-    fn method() -> Method {
-        Method::POST
-    }
-    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
-        format!("/sys/v1/users/change_password")
-    }
-}
-
-impl SdkmsClient {
-    pub fn change_password(&self, req: &PasswordChangeRequest) -> Result<()> {
-        self.execute::<OperationChangePassword>(req, (), None)
-    }
-}
-
-pub struct OperationGetUserAccounts;
-#[allow(unused)]
-impl Operation for OperationGetUserAccounts {
-    type PathParams = ();
-    type QueryParams = ();
-    type Body = ();
-    type Output = HashMap<Uuid, UserAccountFlags>;
-
-    fn method() -> Method {
-        Method::GET
-    }
-    fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
-        format!("/sys/v1/users/accounts")
-    }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
-        None
-    }
-}
-
-impl SdkmsClient {
-    pub fn get_user_accounts(&self) -> Result<HashMap<Uuid, UserAccountFlags>> {
-        self.execute::<OperationGetUserAccounts>(&(), (), None)
-    }
-}
-
-pub struct OperationDeleteUserAccount;
-#[allow(unused)]
-impl Operation for OperationDeleteUserAccount {
+impl Operation for OperationUpdateUser {
     type PathParams = (Uuid,);
     type QueryParams = ();
-    type Body = ();
-    type Output = ();
+    type Body = UserRequest;
+    type Output = User;
 
     fn method() -> Method {
-        Method::DELETE
+        Method::PATCH
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
-        format!("/sys/v1/users/{id}/accounts", id = p.0)
-    }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
-        None
+        format!("/sys/v1/users/{id}", id = p.0)
     }
 }
 
 impl SdkmsClient {
-    pub fn delete_user_account(&self, id: &Uuid) -> Result<()> {
-        self.execute::<OperationDeleteUserAccount>(&(), (id,), None)
+    pub fn update_user(&self, id: &Uuid, req: &UserRequest) -> Result<User> {
+        self.execute::<OperationUpdateUser>(req, (id,), None)
     }
 }
 
-pub struct OperationGenerateRecoveryCodes;
+pub struct OperationValidateToken;
 #[allow(unused)]
-impl Operation for OperationGenerateRecoveryCodes {
-    type PathParams = ();
+impl Operation for OperationValidateToken {
+    type PathParams = (Uuid,);
     type QueryParams = ();
-    type Body = ();
-    type Output = RecoveryCodes;
+    type Body = ValidateTokenRequest;
+    type Output = ValidateTokenResponse;
 
     fn method() -> Method {
         Method::POST
     }
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
-        format!("/sys/v1/users/generate_recovery_codes")
-    }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
-        None
+        format!("/sys/v1/users/{id}/validate_token", id = p.0)
     }
 }
 
 impl SdkmsClient {
-    pub fn generate_recovery_codes(&self) -> Result<RecoveryCodes> {
-        self.execute::<OperationGenerateRecoveryCodes>(&(), (), None)
+    pub fn validate_token(&self, id: &Uuid, req: &ValidateTokenRequest) -> Result<ValidateTokenResponse> {
+        self.execute::<OperationValidateToken>(req, (id,), None)
     }
 }
+

--- a/src/generated/users_generated.rs
+++ b/src/generated/users_generated.rs
@@ -8,18 +8,18 @@ use super::*;
 
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
 pub struct ConfirmEmailRequest {
-    pub confirm_token: String
+    pub confirm_token: String,
 }
 
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
 pub struct ConfirmEmailResponse {
-    pub user_email: String
+    pub user_email: String,
 }
 
 /// Initiate password reset sequence.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ForgotPasswordRequest {
-    pub user_email: String
+    pub user_email: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Default)]
@@ -29,7 +29,7 @@ pub struct ListUsersParams {
     pub limit: Option<usize>,
     pub offset: Option<usize>,
     #[serde(flatten)]
-    pub sort: UserSort
+    pub sort: UserSort,
 }
 
 impl UrlEncode for ListUsersParams {
@@ -54,14 +54,14 @@ impl UrlEncode for ListUsersParams {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct PasswordChangeRequest {
     pub current_password: String,
-    pub new_password: String
+    pub new_password: String,
 }
 
 /// Request to perform a password reset.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct PasswordResetRequest {
     pub reset_token: String,
-    pub new_password: String
+    pub new_password: String,
 }
 
 /// Accept/reject invitations to join account.
@@ -72,13 +72,13 @@ pub struct ProcessInviteRequest {
     pub accepts: Option<HashSet<Uuid>>,
     /// Optional list of account IDs to reject.
     #[serde(default)]
-    pub rejects: Option<HashSet<Uuid>>
+    pub rejects: Option<HashSet<Uuid>>,
 }
 
 /// U2F recovery codes.
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
 pub struct RecoveryCodes {
-    pub recovery_codes: Vec<String>
+    pub recovery_codes: Vec<String>,
 }
 
 /// Request to signup a new user.
@@ -91,7 +91,7 @@ pub struct SignupRequest {
     #[serde(default)]
     pub first_name: Option<String>,
     #[serde(default)]
-    pub last_name: Option<String>
+    pub last_name: Option<String>,
 }
 
 /// Description of a U2F device to add for two factor authentication.
@@ -101,26 +101,26 @@ pub struct U2fAddDeviceRequest {
     pub name: String,
     pub registration_data: Blob,
     pub client_data: Blob,
-    pub version: String
+    pub version: String,
 }
 
 /// Request to delete a U2F device.
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
 pub struct U2fDelDeviceRequest {
-    pub name: String
+    pub name: String,
 }
 
 /// A U2f device that may be used for second factor authentication.
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
 pub struct U2fDevice {
-    pub name: String
+    pub name: String,
 }
 
 /// Request to rename a U2F device.
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
 pub struct U2fRenameDeviceRequest {
     pub old_name: String,
-    pub new_name: String
+    pub new_name: String,
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
@@ -134,7 +134,7 @@ pub struct User {
     pub email_verified: Option<bool>,
     #[serde(default)]
     pub first_name: Option<String>,
-    pub groups: HashMap<Uuid,UserGroupRole>,
+    pub groups: HashMap<Uuid, UserGroupRole>,
     #[serde(default)]
     pub has_account: Option<bool>,
     #[serde(default)]
@@ -148,13 +148,13 @@ pub struct User {
     pub u2f_devices: Vec<U2fDevice>,
     #[serde(default)]
     pub user_email: Option<String>,
-    pub user_id: Uuid
+    pub user_id: Uuid,
 }
 
 /// User's role and state in an account.
 pub use self::user_flags::UserAccountFlags;
 pub mod user_flags {
-    bitflags_set!{
+    bitflags_set! {
         pub struct UserAccountFlags: u64 {
             const ACCOUNTADMINISTRATOR = 0x0000000000000001;
             const ACCOUNTMEMBER = 0x0000000000000002;
@@ -170,11 +170,11 @@ pub struct UserRequest {
     #[serde(default)]
     pub account_role: Option<UserAccountFlags>,
     #[serde(default)]
-    pub add_groups: Option<HashMap<Uuid,UserGroupRole>>,
+    pub add_groups: Option<HashMap<Uuid, UserGroupRole>>,
     #[serde(default)]
     pub add_u2f_devices: Option<Vec<U2fAddDeviceRequest>>,
     #[serde(default)]
-    pub del_groups: Option<HashMap<Uuid,UserGroupRole>>,
+    pub del_groups: Option<HashMap<Uuid, UserGroupRole>>,
     #[serde(default)]
     pub del_u2f_devices: Option<Vec<U2fDelDeviceRequest>>,
     #[serde(default)]
@@ -186,27 +186,27 @@ pub struct UserRequest {
     #[serde(default)]
     pub last_name: Option<String>,
     #[serde(default)]
-    pub mod_groups: Option<HashMap<Uuid,UserGroupRole>>,
+    pub mod_groups: Option<HashMap<Uuid, UserGroupRole>>,
     #[serde(default)]
     pub rename_u2f_devices: Option<Vec<U2fRenameDeviceRequest>>,
     #[serde(default)]
     pub user_email: Option<String>,
     #[serde(default)]
-    pub user_password: Option<String>
+    pub user_password: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum UserSort {
-    ByUserId {
-        order: Order,
-        start: Option<Uuid>
-    }
+    ByUserId { order: Order, start: Option<Uuid> },
 }
 
 impl UrlEncode for UserSort {
     fn url_encode(&self, m: &mut HashMap<String, String>) {
         match *self {
-            UserSort::ByUserId{ ref order, ref start } => {
+            UserSort::ByUserId {
+                ref order,
+                ref start,
+            } => {
                 m.insert("sort".to_string(), format!("user_id:{}", order));
                 if let Some(v) = start {
                     m.insert("start".to_string(), v.to_string());
@@ -218,12 +218,12 @@ impl UrlEncode for UserSort {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ValidateTokenRequest {
-    pub reset_token: String
+    pub reset_token: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ValidateTokenResponse {
-    pub user_email: String
+    pub user_email: String,
 }
 
 pub struct OperationChangePassword;
@@ -265,7 +265,11 @@ impl Operation for OperationConfirmEmail {
 }
 
 impl SdkmsClient {
-    pub fn confirm_email(&self, id: &Uuid, req: &ConfirmEmailRequest) -> Result<ConfirmEmailResponse> {
+    pub fn confirm_email(
+        &self,
+        id: &Uuid,
+        req: &ConfirmEmailRequest,
+    ) -> Result<ConfirmEmailResponse> {
         self.execute::<OperationConfirmEmail>(req, (id,), None)
     }
 }
@@ -284,7 +288,10 @@ impl Operation for OperationDeleteStale {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/users/{id}", id = p.0)
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
+        None
+    }
+}
 
 impl SdkmsClient {
     pub fn delete_stale(&self, id: &Uuid) -> Result<()> {
@@ -306,7 +313,10 @@ impl Operation for OperationDeleteUser {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/users")
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
+        None
+    }
+}
 
 impl SdkmsClient {
     pub fn delete_user(&self) -> Result<()> {
@@ -328,7 +338,10 @@ impl Operation for OperationDeleteUserAccount {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/users/{id}/accounts", id = p.0)
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
+        None
+    }
+}
 
 impl SdkmsClient {
     pub fn delete_user_account(&self, id: &Uuid) -> Result<()> {
@@ -372,7 +385,10 @@ impl Operation for OperationGenerateRecoveryCodes {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/users/generate_recovery_codes")
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
+        None
+    }
+}
 
 impl SdkmsClient {
     pub fn generate_recovery_codes(&self) -> Result<RecoveryCodes> {
@@ -394,7 +410,10 @@ impl Operation for OperationGetUser {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/users/{id}", id = p.0)
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
+        None
+    }
+}
 
 impl SdkmsClient {
     pub fn get_user(&self, id: &Uuid) -> Result<User> {
@@ -408,7 +427,7 @@ impl Operation for OperationGetUserAccounts {
     type PathParams = ();
     type QueryParams = ();
     type Body = ();
-    type Output = HashMap<Uuid,UserAccountFlags>;
+    type Output = HashMap<Uuid, UserAccountFlags>;
 
     fn method() -> Method {
         Method::GET
@@ -416,10 +435,13 @@ impl Operation for OperationGetUserAccounts {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/users/accounts")
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
+        None
+    }
+}
 
 impl SdkmsClient {
-    pub fn get_user_accounts(&self) -> Result<HashMap<Uuid,UserAccountFlags>> {
+    pub fn get_user_accounts(&self) -> Result<HashMap<Uuid, UserAccountFlags>> {
         self.execute::<OperationGetUserAccounts>(&(), (), None)
     }
 }
@@ -460,7 +482,10 @@ impl Operation for OperationListUsers {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/users?{q}", q = q.encode())
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
+        None
+    }
+}
 
 impl SdkmsClient {
     pub fn list_users(&self, query_params: Option<&ListUsersParams>) -> Result<Vec<User>> {
@@ -504,7 +529,10 @@ impl Operation for OperationResendConfirmEmail {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/users/resend_confirm_email")
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
+        None
+    }
+}
 
 impl SdkmsClient {
     pub fn resend_confirm_email(&self) -> Result<()> {
@@ -526,7 +554,10 @@ impl Operation for OperationResendInvite {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/users/{id}/resend_invite", id = p.0)
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
+        None
+    }
+}
 
 impl SdkmsClient {
     pub fn resend_invite(&self, id: &Uuid) -> Result<()> {
@@ -617,8 +648,11 @@ impl Operation for OperationValidateToken {
 }
 
 impl SdkmsClient {
-    pub fn validate_token(&self, id: &Uuid, req: &ValidateTokenRequest) -> Result<ValidateTokenResponse> {
+    pub fn validate_token(
+        &self,
+        id: &Uuid,
+        req: &ValidateTokenRequest,
+    ) -> Result<ValidateTokenResponse> {
         self.execute::<OperationValidateToken>(req, (id,), None)
     }
 }
-

--- a/src/generated/version_generated.rs
+++ b/src/generated/version_generated.rs
@@ -10,7 +10,7 @@ use super::*;
 #[derive(Copy, PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
 pub enum ServerMode {
     Software,
-    Sgx
+    Sgx,
 }
 
 /// Information about the service version.
@@ -24,7 +24,7 @@ pub struct VersionResponse {
     /// FIPS level at which the service in running. If this field is absent, then the service is
     /// not running in FIPS compliant mode.
     #[serde(default)]
-    pub fips_level: Option<u8>
+    pub fips_level: Option<u8>,
 }
 
 pub struct OperationVersion;
@@ -41,11 +41,13 @@ impl Operation for OperationVersion {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/version")
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
+        None
+    }
+}
 
 impl SdkmsClient {
     pub fn version(&self) -> Result<VersionResponse> {
         self.execute::<OperationVersion>(&(), (), None)
     }
 }
-

--- a/src/generated/version_generated.rs
+++ b/src/generated/version_generated.rs
@@ -5,13 +5,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::*;
-use serde::{Deserialize, Serialize};
 
-/// Server mode.
-#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
+/// Server execution mode.
+#[derive(Copy, PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
 pub enum ServerMode {
     Software,
-    Sgx,
+    Sgx
 }
 
 /// Information about the service version.
@@ -25,7 +24,7 @@ pub struct VersionResponse {
     /// FIPS level at which the service in running. If this field is absent, then the service is
     /// not running in FIPS compliant mode.
     #[serde(default)]
-    pub fips_level: Option<u8>,
+    pub fips_level: Option<u8>
 }
 
 pub struct OperationVersion;
@@ -42,13 +41,11 @@ impl Operation for OperationVersion {
     fn path(p: <Self::PathParams as TupleRef>::Ref, q: Option<&Self::QueryParams>) -> String {
         format!("/sys/v1/version")
     }
-    fn to_body(body: &Self::Body) -> Option<serde_json::Value> {
-        None
-    }
-}
+    fn to_body(body: &Self::Body) -> Option<serde_json::Value> { None }}
 
 impl SdkmsClient {
     pub fn version(&self) -> Result<VersionResponse> {
         self.execute::<OperationVersion>(&(), (), None)
     }
 }
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@
 //!         alg: None,
 //!         ad: None,
 //!         tag: None,
+//!         masked: None,
 //!     })?;
 //!
 //!     let plain = String::from_utf8(decrypt_resp.plain.into()).expect("valid utf8");

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -28,12 +28,21 @@
 ///
 /// The output of `test_set` in JSON representation: `["BIT_0", "BIT_2"]`.
 macro_rules! bitflags_set {
-    (pub struct $n:ident: $t:ty {
-        $(const $f:ident = $v:expr);* $(;)*
-    }) => {
+    ($(#[$outer:meta])*
+        $vis:vis struct $n:ident: $t:ty {
+            $(
+                $(#[$inner:ident $($args:tt)*])*
+                const $f:ident = $v:expr;
+            )*
+        }
+    ) => {
         bitflags! {
-            pub struct $n: $t {
-                $(const $f = $v;)*
+            $(#[$outer])*
+            $vis struct $n: $t {
+                $(
+                    $(#[$inner $($args)*])*
+                    const $f = $v;
+                )*
             }
         }
 

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -25,7 +25,7 @@ pub trait Operation {
 }
 
 pub trait UrlEncode {
-    fn url_encode(&self, m: &mut HashMap<&'static str, String>);
+    fn url_encode(&self, m: &mut HashMap<String, String>);
 
     fn encode(&self) -> String {
         let mut m = HashMap::new();
@@ -42,11 +42,11 @@ pub trait UrlEncode {
 }
 
 impl UrlEncode for () {
-    fn url_encode(&self, _m: &mut HashMap<&'static str, String>) {}
+    fn url_encode(&self, _m: &mut HashMap<String, String>) {}
 }
 
 impl<T: UrlEncode> UrlEncode for Option<T> {
-    fn url_encode(&self, m: &mut HashMap<&'static str, String>) {
+    fn url_encode(&self, m: &mut HashMap<String, String>) {
         if let Some(val) = self {
             val.url_encode(m);
         }
@@ -54,7 +54,7 @@ impl<T: UrlEncode> UrlEncode for Option<T> {
 }
 
 impl<T: UrlEncode> UrlEncode for &T {
-    fn url_encode(&self, m: &mut HashMap<&'static str, String>) {
+    fn url_encode(&self, m: &mut HashMap<String, String>) {
         T::url_encode(self, m);
     }
 }


### PR DESCRIPTION
This change should allow the client to work with latest api model

Changes include:
- Changed `UrlEncode` definitions 
- Added missing trait implementations in `api_model.rs`
- Split `mod client` to async and blocking interfaces and added `async` feature flag
- Modified examples to work with latest api model 

Note: will raise separate PR for async client.